### PR TITLE
directly use channel to get async response

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -31,7 +31,7 @@ type controller struct {
 	specialEndpoints []Endpoint
 	bootstrap        []Endpoint
 
-	shareListener map[uint32]func(*Parcel)
+	shareListener map[uint32]chan *Parcel
 	shareMtx      sync.RWMutex
 
 	lastPeerDial time.Time
@@ -73,7 +73,7 @@ func newController(network *Network) (*controller, error) {
 	c.peerData = make(chan peerParcel, conf.ChannelCapacity)
 
 	c.special = make(map[string]bool)
-	c.shareListener = make(map[uint32]func(*Parcel))
+	c.shareListener = make(map[uint32]chan *Parcel)
 
 	// CAT
 	c.lastRound = time.Now()

--- a/controller_routing.go
+++ b/controller_routing.go
@@ -61,8 +61,8 @@ func (c *controller) manageData() {
 				}
 			case TypePeerResponse:
 				c.shareMtx.RLock()
-				if f, ok := c.shareListener[peer.NodeID]; ok {
-					f(parcel)
+				if async, ok := c.shareListener[peer.NodeID]; ok {
+					async <- parcel
 				}
 				c.shareMtx.RUnlock()
 			default:


### PR DESCRIPTION
This eliminates the need for a closure and make a better use of channel as a mean to pass meaningful data across.

I also removed the payload of the request that seemed superfluous to me, let me now if I went too far in the cleaning.