### PR TITLE
Correctly break peer share list

### DIFF
--- a/controller_cat.go
+++ b/controller_cat.go
@@ -109,6 +109,12 @@ func (c *controller) sharePeers(peer *Peer, list []Endpoint) {
 		c.logger.WithError(err).Error("Failed to marshal peer list to json")
 		return
 	}
+
+	if len(payload) == 0 {
+		c.logger.Debugf("No peers to share with %s", peer)
+		return
+	}
+
 	c.logger.Debugf("Sharing %d peers with %s", len(list), peer)
 	parcel := newParcel(TypePeerResponse, payload)
 	peer.Send(parcel)

--- a/controller_cat.go
+++ b/controller_cat.go
@@ -82,18 +82,16 @@ func (c *controller) trimShare(list []Endpoint, shuffle bool) []Endpoint {
 	return list
 }
 
-func (c *controller) makePeerShare(ep Endpoint) []Endpoint {
+func (c *controller) makePeerShare(exclude Endpoint) []Endpoint {
 	var list []Endpoint
-	tmp := c.peers.Slice()
-	var i int
+	peers := c.peers.Slice()
 
-	cmp := ep.String()
-	for _, i = range c.net.rng.Perm(len(tmp)) {
-		if tmp[i].Endpoint.String() == cmp {
+	for i := range c.net.rng.Perm(len(peers)) {
+		if exclude.Equal(peers[i].Endpoint) {
 			continue
 		}
-		list = append(list, tmp[i].Endpoint)
-		if uint(len(tmp)) >= c.net.conf.PeerShareAmount {
+		list = append(list, peers[i].Endpoint)
+		if uint(len(list)) >= c.net.conf.PeerShareAmount {
 			break
 		}
 	}

--- a/controller_cat.go
+++ b/controller_cat.go
@@ -86,7 +86,7 @@ func (c *controller) makePeerShare(exclude Endpoint) []Endpoint {
 	var list []Endpoint
 	peers := c.peers.Slice()
 
-	for i := range c.net.rng.Perm(len(peers)) {
+	for _, i := range c.net.rng.Perm(len(peers)) {
 		if exclude.Equal(peers[i].Endpoint) {
 			continue
 		}

--- a/endpoint.go
+++ b/endpoint.go
@@ -56,3 +56,8 @@ func (ep Endpoint) Valid() bool {
 	}
 	return false
 }
+
+// Equals returns true if both endpoints are the same
+func (ep Endpoint) Equal(o Endpoint) bool {
+	return ep.IP == o.IP && ep.Port == o.Port
+}

--- a/endpoint_test.go
+++ b/endpoint_test.go
@@ -115,3 +115,35 @@ func TestEndpoint_Valid(t *testing.T) {
 		})
 	}
 }
+
+func TestEndpoint_Equal(t *testing.T) {
+	ep := func(ip, port string) Endpoint {
+		return Endpoint{IP: ip, Port: port}
+	}
+
+	type args struct {
+		o Endpoint
+	}
+	tests := []struct {
+		name string
+		ep   Endpoint
+		args args
+		want bool
+	}{
+		{"both empty", Endpoint{}, args{Endpoint{}}, true},
+		{"both empty strings", ep("", ""), args{ep("", "")}, true},
+		{"localhost, no port", ep("localhost", ""), args{ep("localhost", "")}, true},
+		{"no ip, same port", ep("", "80"), args{ep("", "80")}, true},
+		{"both set", ep("127.0.0.1", "8108"), args{ep("127.0.0.1", "8108")}, true},
+		{"port wrong", ep("127.0.0.1", "51"), args{ep("127.0.0.1", "50")}, false},
+		{"ip wrong", ep("127.0.0.1", "80"), args{ep("127.0.0.2", "80")}, false},
+		{"both wrong", ep("127.0.0.1", "80"), args{ep("127.0.0.2", "81")}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.ep.Equal(tt.args.o); got != tt.want {
+				t.Errorf("Endpoint.Equal() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
closes: #3 

* Adds Equal function to endpoints
* Rename parameters to `exclude`
* Rename `tmp` to `peers`
* Break on growing `list`
* Don't send peer shares if the list is empty
