### PR TITLE
refactor: cat replenish polish

### DIFF
--- a/controller_cat.go
+++ b/controller_cat.go
@@ -141,6 +141,7 @@ func (c *controller) asyncPeerRequest(peer *Peer) ([]Endpoint, error) {
 	}()
 
 	req := newParcel(TypePeerRequest, []byte("Peer Request"))
+	peer.lastPeerSend = time.Now()
 	peer.Send(req)
 
 	select {
@@ -154,20 +155,26 @@ func (c *controller) asyncPeerRequest(peer *Peer) ([]Endpoint, error) {
 
 // catReplenish is the loop that brings the node up to the desired number of connections.
 // Does nothing if we have enough peers, otherwise it sends a peer request to a random peer.
+// The sources of new peers are, in order of priority:
+// (0. Bootstrap peers saved from previous run)
+// 1. Special peers
+// 2. Seed peers
+// 3. Random new peers shared by a random current peer
+// 4. Random new peers from peers rejecting our connection
 func (c *controller) catReplenish() {
 	c.logger.Debug("Replenish loop started")
 	defer c.logger.Debug("Replenish loop ended")
 
-	deny := func(ep Endpoint) bool {
-		return c.peers.Connected(ep) || c.isBannedEndpoint(ep) || !c.dialer.CanDial(ep)
+	canDial := func(ep Endpoint) bool {
+		return !c.peers.Connected(ep) && !c.isBannedEndpoint(ep) && c.dialer.CanDial(ep)
 	}
 
 	// bootstrap
 	if len(c.bootstrap) > 0 {
 		c.logger.Infof("Attempting to connect to %d peers from bootstrap", len(c.bootstrap))
 		for _, e := range c.bootstrap {
-			if !deny(e) {
-				_, _ = c.Dial(e)
+			if canDial(e) {
+				c.Dial(e)
 			}
 		}
 		c.bootstrap = nil
@@ -182,39 +189,32 @@ func (c *controller) catReplenish() {
 			continue
 		}
 
-		// reseed if necessary
-		min := c.net.conf.MinReseed
-		if uint(c.seed.size()) < min {
-			min = uint(c.seed.size()) - 1
-		}
-
 		// try special first
 		for _, sp := range c.specialEndpoints {
-			if deny(sp) {
-				continue
+			if canDial(sp) {
+				connect = append(connect, sp)
 			}
-			connect = append(connect, sp)
 		}
 
-		if uint(c.peers.Total()) <= min || time.Since(lastReseed) > c.net.conf.PeerReseedInterval {
+		// reseed if necessary
+		minReseed := c.net.conf.MinReseed
+		if uint(c.seed.size()) < minReseed {
+			minReseed = uint(c.seed.size()) - 1
+		}
+
+		if uint(c.peers.Total()) <= minReseed || time.Since(lastReseed) > c.net.conf.PeerReseedInterval {
 			seeds := c.seed.retrieve()
 			// shuffle to hit different seeds
 			c.net.rng.Shuffle(len(seeds), func(i, j int) {
 				seeds[i], seeds[j] = seeds[j], seeds[i]
 			})
 			for _, s := range seeds {
-				if deny(s) {
-					continue
+				if canDial(s) {
+					connect = append(connect, s)
 				}
-				connect = append(connect, s)
 			}
 			lastReseed = time.Now()
 		}
-
-		// if we connect to a peer that's full it gives us some alternatives
-		// left unchecked, this can be a very long loop, therefore we are limiting it
-		// sum(special, seeds) + 5 more
-		var attemptsLimit = len(connect) + 5
 
 		if c.peers.Total() > 0 {
 			rand := c.randomPeersConditional(1, func(p *Peer) bool {
@@ -223,13 +223,12 @@ func (c *controller) catReplenish() {
 			if len(rand) > 0 {
 				p := rand[0]
 				// error just means timeout of async request
-				p.lastPeerSend = time.Now()
 				if eps, err := c.asyncPeerRequest(p); err == nil {
 					// pick random share from peer
 					if len(eps) > 0 {
 						el := c.net.rng.Intn(len(eps))
 						ep := eps[el]
-						if !deny(ep) {
+						if canDial(ep) {
 							connect = append(connect, ep)
 						}
 					}
@@ -237,13 +236,20 @@ func (c *controller) catReplenish() {
 			}
 		}
 
-		var ep Endpoint
+		// if we connect to a peer that's full it gives us some alternatives
+		// left unchecked, this can be a very long loop, therefore we are limiting it
+		// sum(special, seeds) + 5 more
+		attemptsLimit := len(connect) + 5
 		var attempts int
-		for len(connect) > 0 && attempts < attemptsLimit {
-			ep = connect[0]
+
+		for len(connect) > 0 &&
+			attempts < attemptsLimit &&
+			uint(c.peers.Total()) < c.net.conf.Target {
+
+			ep := connect[0]
 			connect = connect[1:]
 
-			if deny(ep) {
+			if !canDial(ep) {
 				continue
 			}
 
@@ -252,10 +258,6 @@ func (c *controller) catReplenish() {
 				for _, alt := range alts {
 					connect = append(connect, alt)
 				}
-			}
-
-			if uint(c.peers.Total()) >= c.net.conf.Target {
-				break
 			}
 		}
 


### PR DESCRIPTION
Spent sometime carefully reading the catReplenish function as it looks a pretty important functions. Only found some minor polish details that help the readability and comprehension, to me at least, so we can discuss it.

- Added a comment about the sources of new peers and their priority order
- I changed `deny` for `canDial`. It allows to remove some negation in condition and have condition read `if canDial then add to the list of endpoints to try to connect to` instead of having a guard statement with immediate continue. Matter of style but, I think it's slightly better...
- I moved some small block of codes that were declared "too early", for instance `minReseed` declaration happening before the special peers handling while not being until after it. (same for the declaration of `attemptsLimit`)
- Moved peer.lastPeerSend as close as possible to the actual send, for consistency