### PR TITLE
Endpoint and other cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ The CAT (Cyclic Auto Truncate) is a cyclic peering strategy to prevent a rigid n
 Rounds run once every 15 minutes (config: `RoundTime`) and does the following:
 
 1. Persist current peer endpoints and bans in the peer file (config: `PersistFile`)
-2. If there are more than 30 peers (config: `Drop`), it randomly selects non-special peers to drop to reach 30 peers.
+2. If there are more than 30 peers (config: `DropTo`), it randomly selects non-special peers to drop to reach 30 peers.
 
 ### Replenish
 
-The goal of Replenish is to reach 32 (config: `Target`) active connections. If there are 32 or more connections, Replenish waits. Otherwise, it runs once a second.
+The goal of Replenish is to reach 32 (config: `TargetPeers`) active connections. If there are 32 or more connections, Replenish waits. Otherwise, it runs once a second.
 
 Once on startup, if the peer file is less than an hour old (config: `PersistAge`) Replenish will try to re-establish those connections first. This improves reconnection speeds after rebooting a node.
 

--- a/configuration.go
+++ b/configuration.go
@@ -40,10 +40,10 @@ type Configuration struct {
 	// ip is considered special
 	Special string
 
-	// PersistFile is the filepath to the file to save peers. It is persisted in every CAT round
-	PersistFile string
-	// PersistAge is the maximum age of the peer file to try and bootstrap peers from
-	PersistAge time.Duration
+	// PeerCacheFile is the filepath to the file to save peers. It is persisted in every CAT round
+	PeerCacheFile string
+	// PeerCacheAge is the maximum age of the peer file to try and bootstrap peers from
+	PeerCacheAge time.Duration
 
 	// to count as being connected
 	// PeerShareAmount is the number of peers we share
@@ -131,8 +131,8 @@ func DefaultP2PConfiguration() (c Configuration) {
 	c.PeerIPLimitOutgoing = 0
 	c.ManualBan = time.Hour * 24 * 7 // a week
 
-	c.PersistFile = ""
-	c.PersistAge = time.Hour //
+	c.PeerCacheFile = ""
+	c.PeerCacheAge = time.Hour //
 
 	c.Incoming = 36
 	c.Fanout = 8

--- a/configuration.go
+++ b/configuration.go
@@ -50,10 +50,15 @@ type Configuration struct {
 	PeerShareAmount uint
 
 	// CAT Settings
+	// How often to do cat rounds
 	RoundTime time.Duration
-	Target    uint
-	Max       uint
-	Drop      uint
+	// Desired amount of peers
+	TargetPeers uint
+	// Hard cap of connections
+	MaxPeers uint
+	// Amount of peers to drop down to
+	DropTo uint
+	// Reseed if there are fewer than this peers
 	MinReseed uint
 	Incoming  uint // maximum inbound connections, 0 <= Incoming <= Max
 
@@ -133,9 +138,9 @@ func DefaultP2PConfiguration() (c Configuration) {
 	c.Fanout = 8
 	c.PeerShareAmount = 3 // CAT share
 	c.RoundTime = time.Minute * 15
-	c.Target = 32
-	c.Max = 36
-	c.Drop = 30
+	c.TargetPeers = 32
+	c.MaxPeers = 36
+	c.DropTo = 30
 	c.MinReseed = 10
 
 	c.BindIP = "" // bind to all
@@ -160,7 +165,7 @@ func DefaultP2PConfiguration() (c Configuration) {
 
 // Sanitize automatically adjusts some variables that are dependent on others
 func (c *Configuration) Sanitize() {
-	if c.Incoming > c.Max {
-		c.Incoming = c.Max
+	if c.Incoming > c.MaxPeers {
+		c.Incoming = c.MaxPeers
 	}
 }

--- a/controller.go
+++ b/controller.go
@@ -82,13 +82,13 @@ func newController(network *Network) (*controller, error) {
 	c.peers = NewPeerStore()
 	c.setSpecial(conf.Special)
 
-	if persist, err := c.loadPersist(); err != nil || persist == nil {
+	if cache, err := c.loadPeerCache(); err != nil || cache == nil {
 		c.logger.Infof("no valid bootstrap file found")
 		c.bans = make(map[string]time.Time)
 		c.bootstrap = nil
-	} else if persist != nil {
-		c.bans = persist.Bans
-		c.bootstrap = persist.Bootstrap
+	} else if cache != nil {
+		c.bans = cache.Bans
+		c.bootstrap = cache.Peers
 	}
 
 	return c, nil

--- a/controller.go
+++ b/controller.go
@@ -91,10 +91,6 @@ func newController(network *Network) (*controller, error) {
 		c.bootstrap = persist.Bootstrap
 	}
 
-	if c.net.prom != nil {
-		c.net.prom.KnownPeers.Set(float64(c.peers.Total()))
-	}
-
 	return c, nil
 }
 

--- a/controller_cat.go
+++ b/controller_cat.go
@@ -19,7 +19,7 @@ func (c *controller) runCatRound() {
 
 	peers := c.peers.Slice()
 
-	toDrop := len(peers) - int(c.net.conf.Drop) // current - target amount
+	toDrop := len(peers) - int(c.net.conf.DropTo) // current - target amount
 
 	if toDrop > 0 {
 		perm := c.net.rng.Perm(len(peers))
@@ -169,7 +169,7 @@ func (c *controller) catReplenish() {
 
 	for {
 		var connect []Endpoint
-		if uint(c.peers.Total()) >= c.net.conf.Target {
+		if uint(c.peers.Total()) >= c.net.conf.TargetPeers {
 			time.Sleep(time.Second)
 			continue
 		}
@@ -246,7 +246,7 @@ func (c *controller) catReplenish() {
 				}
 			}
 
-			if uint(c.peers.Total()) >= c.net.conf.Target {
+			if uint(c.peers.Total()) >= c.net.conf.TargetPeers {
 				break
 			}
 		}

--- a/controller_cat.go
+++ b/controller_cat.go
@@ -96,12 +96,9 @@ func (c *controller) makePeerShare(exclude Endpoint) []Endpoint {
 	return list
 }
 
-// sharePeers creates a list of peers to share and sends it to peer
+// sharePeers shares the list of endpoints with a peer
 func (c *controller) sharePeers(peer *Peer, list []Endpoint) {
-	if peer == nil {
-		return
-	}
-	// CAT select n random active peers
+	// convert to protocol
 	payload, err := peer.prot.MakePeerShare(list)
 	if err != nil {
 		c.logger.WithError(err).Error("Failed to marshal peer list to json")

--- a/controller_cat.go
+++ b/controller_cat.go
@@ -44,26 +44,21 @@ func (c *controller) processPeerShare(peer *Peer, parcel *Parcel) []Endpoint {
 
 	if err != nil {
 		c.logger.WithError(err).Warnf("Failed to unmarshal peer share from peer %s", peer)
+		return nil
 	}
 
 	c.logger.Debugf("Received peer share from %s: %+v", peer, list)
 
 	var res []Endpoint
-	for _, p := range list {
-		if !p.Valid() {
-			c.logger.Infof("Peer %s tried to send us peer share with bad data: %s", peer, p)
+	for _, ep := range list {
+		if !ep.Valid() {
+			c.logger.Infof("Peer %s tried to send us peer share with bad data: %s", peer, ep)
 			return nil
 		}
-		ep, err := NewEndpoint(p.IP, p.Port)
-		if err != nil {
-			c.logger.WithError(err).Infof("Unable to register endpoint %s:%s from peer %s", p.IP, p.Port, peer)
-		} else if !c.isBannedEndpoint(ep) {
+
+		if !c.isBannedEndpoint(ep) {
 			res = append(res, ep)
 		}
-	}
-
-	if c.net.prom != nil {
-		c.net.prom.KnownPeers.Set(float64(c.peers.Total()))
 	}
 
 	return res

--- a/debug.go
+++ b/debug.go
@@ -12,7 +12,7 @@ import (
 func (n *Network) DebugMessage() (string, string, int) {
 	hv := ""
 	s := n.controller.peers.Slice()
-	r := fmt.Sprintf("\nONLINE: (%d/%d/%d)\n", len(s), n.conf.Target, n.conf.Max)
+	r := fmt.Sprintf("\nONLINE: (%d/%d/%d)\n", len(s), n.conf.TargetPeers, n.conf.MaxPeers)
 	count := len(s)
 	for _, p := range s {
 

--- a/endpoint.go
+++ b/endpoint.go
@@ -53,10 +53,6 @@ func (ep Endpoint) Valid() bool {
 		return false
 	}
 
-	if parse := net.ParseIP(ep.IP); parse == nil {
-		return false
-	}
-
 	return true
 }
 

--- a/endpoint.go
+++ b/endpoint.go
@@ -13,16 +13,10 @@ type Endpoint struct {
 
 // NewEndpoint creates an Endpoint struct from a given ip and port, throws error if ip could not be resolved
 func NewEndpoint(ip, port string) (Endpoint, error) {
-	if len(ip) == 0 || len(port) == 0 {
-		return Endpoint{}, fmt.Errorf("no ip or port given (%s:%s)", ip, port)
-	}
-
-	parse := net.ParseIP(ip)
-	if parse == nil {
-		return Endpoint{}, fmt.Errorf("unable to parse ip: %s", ip)
-	}
-
 	ep := Endpoint{ip, port}
+	if !ep.Valid() {
+		return Endpoint{}, fmt.Errorf("(%s:%s) is not a valid endpoint", ip, port)
+	}
 	return ep, nil
 }
 
@@ -51,10 +45,19 @@ func (ep Endpoint) String() string {
 
 // Verify checks if the data is usable. Does not check if the remote address works
 func (ep Endpoint) Valid() bool {
-	if _, err := strconv.Atoi(ep.Port); err == nil {
-		return ep.Port != "0" && ep.IP != ""
+	if ep.IP == "" || ep.Port == "" {
+		return false
 	}
-	return false
+
+	if p, err := strconv.Atoi(ep.Port); err != nil || p == 0 {
+		return false
+	}
+
+	if parse := net.ParseIP(ep.IP); parse == nil {
+		return false
+	}
+
+	return true
 }
 
 // Equals returns true if both endpoints are the same

--- a/endpoint_test.go
+++ b/endpoint_test.go
@@ -21,18 +21,19 @@ func TestNewEndpoint(t *testing.T) {
 		{"empty", args{"", ""}, Endpoint{}, true},
 		{"no port", args{"127.0.0.1", ""}, Endpoint{}, true},
 		{"no ip", args{"", "8088"}, Endpoint{}, true},
-		{"invalid ip", args{"127.0.0.256", "8088"}, Endpoint{}, true},
-		{"hostname", args{"localhost", "8088"}, Endpoint{}, true}, // likely uses ::1 ipv6 address
+		//{"invalid ip", args{"127.0.0.256", "8088"}, Endpoint{}, true}, // technically a valid hostname
+		{"hostname", args{"localhost", "8088"}, Endpoint{"localhost", "8088"}, false}, // likely uses ::1 ipv6 address
+		{"punycode", args{"xn--qei9019maa.xn--z38hpa", "8088"}, Endpoint{"xn--qei9019maa.xn--z38hpa", "8088"}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := NewEndpoint(tt.args.addr, tt.args.port)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("NewIP() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("NewEndpoint() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewIP() = %v, want %v", got, tt.want)
+				t.Errorf("NewEndpoint() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -55,7 +56,7 @@ func TestParseEndpoint(t *testing.T) {
 		{"no port", args{"127.0.0.1"}, Endpoint{}, true},
 		{"empty", args{""}, Endpoint{}, true},
 		{"no ip", args{":80"}, Endpoint{}, true},
-		{"bad ip", args{"127.0:80"}, Endpoint{}, true},
+		// {"bad ip", args{"127.0:80"}, Endpoint{}, true}, // this is theoretically a valid hostname
 		{"wrong format 1", args{"127.0.0.1,80"}, Endpoint{}, true},
 		{"wrong format 2", args{"127.0.0.1:80 test"}, Endpoint{}, true},
 		{"wrong format 3", args{"ip:127.0.0.1 port:80"}, Endpoint{}, true},
@@ -105,7 +106,15 @@ func TestEndpoint_Valid(t *testing.T) {
 		{"zero port", Endpoint{IP: "127.0.0.1", Port: "0"}, false},
 		{"nonnumeric port", Endpoint{IP: "127.0.0.1", Port: "eighty"}, false},
 		{"nonnumeric port", Endpoint{IP: "127.0.0.1", Port: "80th"}, false},
-		{"hostname", Endpoint{IP: "factom.fct", Port: "8088"}, false},
+		{"localhost", Endpoint{IP: "localhost", Port: "8088"}, true},
+		{"domain name", Endpoint{IP: "factom.fct", Port: "8088"}, true},
+		{"invalid characters", Endpoint{IP: "localho$t", Port: "8088"}, false},
+		{"invalid start", Endpoint{IP: "-test.com", Port: "8088"}, false},
+		{"invalid start middle", Endpoint{IP: "test.-com", Port: "8088"}, false},
+		{"longest hostname", Endpoint{IP: "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcde.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.com", Port: "8088"}, true},
+		{"real domain", Endpoint{IP: "www.google.com", Port: "8088"}, true},
+		{"invalid url", Endpoint{IP: "https://www.google.com", Port: "8088"}, false},
+		{"punycode", Endpoint{IP: "xn--qei9019maa.xn--z38hpa", Port: "8088"}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/endpoint_test.go
+++ b/endpoint_test.go
@@ -22,7 +22,7 @@ func TestNewEndpoint(t *testing.T) {
 		{"no port", args{"127.0.0.1", ""}, Endpoint{}, true},
 		{"no ip", args{"", "8088"}, Endpoint{}, true},
 		{"invalid ip", args{"127.0.0.256", "8088"}, Endpoint{}, true},
-		{"domain lookup", args{"localhost", "8088"}, Endpoint{}, true}, // likely uses ::1 ipv6 address
+		{"hostname", args{"localhost", "8088"}, Endpoint{}, true}, // likely uses ::1 ipv6 address
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -105,7 +105,7 @@ func TestEndpoint_Valid(t *testing.T) {
 		{"zero port", Endpoint{IP: "127.0.0.1", Port: "0"}, false},
 		{"nonnumeric port", Endpoint{IP: "127.0.0.1", Port: "eighty"}, false},
 		{"nonnumeric port", Endpoint{IP: "127.0.0.1", Port: "80th"}, false},
-		{"hostname", Endpoint{IP: "factom.fct", Port: "8088"}, true},
+		{"hostname", Endpoint{IP: "factom.fct", Port: "8088"}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/prometheus.go
+++ b/prometheus.go
@@ -17,8 +17,6 @@ type Prometheus struct {
 	Incoming    prometheus.Gauge // done
 	Outgoing    prometheus.Gauge // done
 
-	KnownPeers prometheus.Gauge // done
-
 	SendRoutines    prometheus.Gauge
 	ReceiveRoutines prometheus.Gauge
 
@@ -49,7 +47,6 @@ func (p *Prometheus) Setup() {
 		p.Connecting = ng("factomd_p2p_peers_connecting", "Number of connections currently dialing or awaiting handshake")
 		p.Incoming = ng("factomd_p2p_peers_incoming", "Number of peers that have dialed to this node")
 		p.Outgoing = ng("factomd_p2p_peers_outgoing", "Number of peers that this node has dialed to")
-		p.KnownPeers = ng("factomd_p2p_peers_known", "Number of peers known to the system")
 		p.SendRoutines = ng("factomd_p2p_tech_sendroutines", "Number of active send routines")
 		p.ReceiveRoutines = ng("factomd_p2p_tech_receiveroutines", "Number of active receive routines")
 		p.ParcelsSent = ng("factomd_p2p_parcels_sent", "Total number of parcels sent out")


### PR DESCRIPTION
https://github.com/WhoSoup/factom-p2p/issues/15:

* Remove unnecessary nil check
* Update comments

https://github.com/WhoSoup/factom-p2p/issues/16:

* Return after error
* Remove unused Prometheus gauge
* Change endpoint verification. Now allows valid hostnames

https://github.com/WhoSoup/factom-p2p/issues/17:

* Rename configuration variables:\
  Drop -> DropTo\
  Target->TargetPeers\
  Max->MaxPeers\

https://github.com/WhoSoup/factom-p2p/issues/18:

* Rename `Persist` to `PeerCache`
  