### PR TITLE
Handshake refactor

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -31,7 +31,7 @@ type controller struct {
 	specialEndpoints []Endpoint
 	bootstrap        []Endpoint
 
-	shareListener map[uint32]chan *Parcel
+	shareListener map[string]chan *Parcel
 	shareMtx      sync.RWMutex
 
 	lastPeerDial time.Time
@@ -73,7 +73,7 @@ func newController(network *Network) (*controller, error) {
 	c.peerData = make(chan peerParcel, conf.ChannelCapacity)
 
 	c.special = make(map[string]bool)
-	c.shareListener = make(map[uint32]chan *Parcel)
+	c.shareListener = make(map[string]chan *Parcel)
 
 	// CAT
 	c.lastRound = time.Now()

--- a/controller_cat.go
+++ b/controller_cat.go
@@ -119,12 +119,12 @@ func (c *controller) asyncPeerRequest(peer *Peer) ([]Endpoint, error) {
 	async := make(chan *Parcel, 1)
 
 	c.shareMtx.Lock()
-	c.shareListener[peer.NodeID] = async
+	c.shareListener[peer.Hash] = async
 	c.shareMtx.Unlock()
 
 	defer func() {
 		c.shareMtx.Lock()
-		delete(c.shareListener, peer.NodeID)
+		delete(c.shareListener, peer.Hash)
 		c.shareMtx.Unlock()
 	}()
 
@@ -233,7 +233,7 @@ func (c *controller) catReplenish() {
 		for len(connect) > 0 &&
 			attempts < attemptsLimit &&
 			uint(c.peers.Total()) < c.net.conf.TargetPeers {
-
+			c.logger.Debugf("replenish loop with %d peers", len(connect))
 			ep := connect[0]
 			connect = connect[1:]
 

--- a/controller_connections.go
+++ b/controller_connections.go
@@ -1,6 +1,8 @@
 package p2p
 
 import (
+	"bytes"
+	"encoding/binary"
 	"encoding/gob"
 	"encoding/json"
 	"fmt"
@@ -90,19 +92,116 @@ func (c *controller) handleIncoming(con net.Conn) {
 		return
 	}
 
-	peer := newPeer(c.net, c.peerStatus, c.peerData)
-	// we are never expecting a reject-alternate for incoming connections
-	if _, err := peer.StartWithHandshake(ep, con, true); err != nil {
-		c.logger.WithError(err).Debugf("Handshake failed for address %s, stopping", ep)
-		peer.Stop()
+	// don't bother with alternatives for incoming connections
+	peer, _, err := c.handshake(host, con, true)
+
+	if err != nil {
+		c.logger.WithError(err).Debugf("inbound connection from %s failed handshake", host)
+		con.Close()
 		return
 	}
 
 	c.logger.Debugf("Incoming handshake success for peer %s, version %s", peer.Hash, peer.prot.Version())
+}
 
-	if c.isBannedEndpoint(peer.Endpoint) {
-		c.logger.Debugf("Peer %s is banned, disconnecting", peer.Hash)
-		peer.Stop()
+func (c *controller) handshake(ip string, con net.Conn, incoming bool) (*Peer, []Endpoint, error) {
+	tmplogger := c.logger.WithField("addr", ip)
+	timeout := time.Now().Add(c.net.conf.HandshakeTimeout)
+
+	nonce := make([]byte, 8) // loopback detection
+	binary.LittleEndian.PutUint64(nonce, c.net.instanceID)
+
+	// upgrade connection to a metrics connection
+	metrics := NewMetricsReadWriter(con)
+
+	handshake := newHandshake(c.net.conf, nonce)
+	decoder := gob.NewDecoder(metrics) // pipe gob through the metrics writer
+	encoder := gob.NewEncoder(metrics)
+	con.SetWriteDeadline(timeout)
+	con.SetReadDeadline(timeout)
+
+	failfunc := func(err error) (*Peer, []Endpoint, error) {
+		tmplogger.WithError(err).Debug("Handshake failed")
+		con.Close()
+		return nil, nil, err
+	}
+
+	err := encoder.Encode(handshake)
+	if err != nil {
+		return failfunc(fmt.Errorf("Failed to send handshake to incoming connection"))
+	}
+
+	var reply Handshake
+	err = decoder.Decode(&reply)
+	if err != nil {
+		return failfunc(fmt.Errorf("Failed to read handshake from incoming connection"))
+	}
+
+	// check basic structure
+	if err = reply.Valid(c.net.conf); err != nil {
+		return failfunc(err)
+	}
+
+	endpoint, err := NewEndpoint(ip, reply.Header.PeerPort)
+	if err != nil {
+		return failfunc(fmt.Errorf("failed to create endpoint: %v", err))
+	}
+
+	if c.isBannedEndpoint(endpoint) {
+		return failfunc(fmt.Errorf("Peer %s is banned, disconnecting", endpoint))
+	}
+
+	// loopback detection
+	if bytes.Equal(reply.Payload, nonce) {
+		return failfunc(fmt.Errorf("loopback"))
+	}
+
+	prot, err := c.determineProtocol(&reply, con, decoder, encoder)
+	if err != nil {
+		return failfunc(err)
+	}
+
+	if reply.Header.Type == TypeRejectAlternative {
+		con.Close()
+		tmplogger.Debug("con rejected with alternatives")
+
+		share, err := prot.ParsePeerShare(reply.Payload)
+		if err != nil {
+			return nil, nil, fmt.Errorf("unable to parse alternatives: %s", err.Error())
+		}
+
+		for _, ep := range share {
+			if !ep.Valid() {
+				return nil, nil, fmt.Errorf("peer provided invalid peer share")
+			}
+		}
+		return nil, share, fmt.Errorf("connection rejected")
+	}
+
+	peer := newPeer(c.net, uint32(reply.Header.NodeID), endpoint, con, prot, metrics, true)
+
+	c.peerStatus <- peerStatus{peer: peer, online: true}
+
+	return peer, nil, nil
+}
+
+func (c *controller) determineProtocol(hs *Handshake, conn net.Conn, decoder *gob.Decoder, encoder *gob.Encoder) (Protocol, error) {
+	v := hs.Header.Version
+	if v > c.net.conf.ProtocolVersion {
+		v = c.net.conf.ProtocolVersion
+	}
+
+	switch v {
+	case 9:
+		v9 := new(ProtocolV9)
+		v9.init(c.net, decoder, encoder)
+		return v9, nil
+	case 10:
+		v10 := new(ProtocolV10)
+		v10.init(decoder, encoder)
+		return v10, nil
+	default:
+		return nil, fmt.Errorf("unknown protocol version %d", v)
 	}
 }
 
@@ -139,31 +238,26 @@ func (c *controller) Dial(ep Endpoint) (bool, []Endpoint) {
 		defer c.net.prom.Connecting.Dec()
 	}
 
-	if ep.Port == "" {
-		ep.Port = c.net.conf.ListenPort
-		c.logger.Debugf("Dialing to %s (with no previously known port)", ep)
-	} else {
-		c.logger.Debugf("Dialing to %s", ep)
-	}
-
+	c.logger.Debugf("Dialing to %s", ep)
 	con, err := c.dialer.Dial(ep)
 	if err != nil {
 		c.logger.WithError(err).Infof("Failed to dial to %s", ep)
 		return false, nil
 	}
 
-	peer := newPeer(c.net, c.peerStatus, c.peerData)
-	if share, err := peer.StartWithHandshake(ep, con, false); err != nil {
+	peer, alternatives, err := c.handshake(ep.IP, con, false)
+	if err != nil { // handshake closes connection
 		if err.Error() == "loopback" {
 			c.logger.Debugf("Banning ourselves for 50 years")
 			c.banEndpoint(ep, time.Hour*24*365*50) // ban for 50 years
-		} else if len(share) > 0 {
-			c.logger.Debugf("Connection declined with alternatives from %s", ep)
-			return false, share
-		} else {
-			c.logger.WithError(err).Debugf("Handshake fail with %s", ep)
+			return false, nil
 		}
-		peer.Stop()
+
+		if len(alternatives) > 0 {
+			c.logger.Debugf("Connection declined with alternatives from %s", ep)
+			return false, alternatives
+		}
+		c.logger.WithError(err).Debugf("Handshake fail with %s", ep)
 		return false, nil
 	}
 

--- a/controller_connections.go
+++ b/controller_connections.go
@@ -194,8 +194,8 @@ func (c *controller) handshake(ip string, con net.Conn, incoming bool) (*Peer, [
 
 	c.peerStatus <- peerStatus{peer: peer, online: true}
 
-	// the v9 handshake is actually a request for peers, so it needs to be processed
-	if prot.Version() == "9" {
+	// a p2p1 node sends a peer request, so it needs to be processed
+	if reply.Header.Type == TypePeerRequest {
 		req := newParcel(TypePeerRequest, []byte("Peer Request"))
 		req.Address = peer.Hash
 		c.peerData <- peerParcel{peer: peer, parcel: req}

--- a/controller_connections.go
+++ b/controller_connections.go
@@ -167,7 +167,7 @@ func (c *controller) handshake(ip string, con net.Conn, incoming bool) (*Peer, [
 		return failfunc(fmt.Errorf("loopback"))
 	}
 
-	prot, err := c.determineProtocol(&reply, con, decoder, encoder)
+	prot, err := c.determineProtocol(reply.Header.Version, con, decoder, encoder)
 	if err != nil {
 		return failfunc(err)
 	}
@@ -204,8 +204,7 @@ func (c *controller) handshake(ip string, con net.Conn, incoming bool) (*Peer, [
 	return peer, nil, nil
 }
 
-func (c *controller) determineProtocol(hs *Handshake, conn net.Conn, decoder *gob.Decoder, encoder *gob.Encoder) (Protocol, error) {
-	v := hs.Header.Version
+func (c *controller) determineProtocol(v uint16, conn net.Conn, decoder *gob.Decoder, encoder *gob.Encoder) (Protocol, error) {
 	if v > c.net.conf.ProtocolVersion {
 		v = c.net.conf.ProtocolVersion
 	}

--- a/controller_connections.go
+++ b/controller_connections.go
@@ -194,6 +194,13 @@ func (c *controller) handshake(ip string, con net.Conn, incoming bool) (*Peer, [
 
 	c.peerStatus <- peerStatus{peer: peer, online: true}
 
+	// the v9 handshake is actually a request for peers, so it needs to be processed
+	if prot.Version() == "9" {
+		req := newParcel(TypePeerRequest, []byte("Peer Request"))
+		req.Address = peer.Hash
+		c.peerData <- peerParcel{peer: peer, parcel: req}
+	}
+
 	return peer, nil, nil
 }
 

--- a/controller_routing.go
+++ b/controller_routing.go
@@ -61,7 +61,7 @@ func (c *controller) manageData() {
 				}
 			case TypePeerResponse:
 				c.shareMtx.RLock()
-				if async, ok := c.shareListener[peer.NodeID]; ok {
+				if async, ok := c.shareListener[peer.Hash]; ok {
 					async <- parcel
 				}
 				c.shareMtx.RUnlock()

--- a/debug.go
+++ b/debug.go
@@ -19,7 +19,7 @@ func (n *Network) DebugMessage() (string, string, int) {
 		metrics := p.GetMetrics()
 		r += fmt.Sprintf("\tPeer %s (MPS %.2f/%.2f) (BPS %.2f/%.2f) (Cap %.2f)\n", p.String(), metrics.MPSDown, metrics.MPSUp, metrics.BPSDown, metrics.BPSUp, metrics.Capacity)
 		edge := ""
-		if n.conf.NodeID < 4 || p.NodeID < 4 {
+		/*if n.conf.NodeID < 4 || p.NodeID < 4 {
 			min := n.conf.NodeID
 			if p.NodeID < min {
 				min = p.NodeID
@@ -28,7 +28,7 @@ func (n *Network) DebugMessage() (string, string, int) {
 				color := []string{"red", "green", "blue"}[min-1]
 				edge = fmt.Sprintf(" {color:%s, weight=3}", color)
 			}
-		}
+		}*/
 		if p.IsIncoming {
 			hv += fmt.Sprintf("%s -> %s:%s%s\n", p.Endpoint, n.conf.BindIP, n.conf.ListenPort, edge)
 		} else {

--- a/peer.go
+++ b/peer.go
@@ -1,10 +1,6 @@
 package p2p
 
 import (
-	"bytes"
-	"encoding/binary"
-	"encoding/gob"
-	"encoding/json"
 	"fmt"
 	"net"
 	"sync"
@@ -26,22 +22,16 @@ type Peer struct {
 	// current state, read only "constants" after the handshake
 	IsIncoming bool
 	Endpoint   Endpoint
-	NodeID     uint32 // a nonce to distinguish multiple nodes behind one endpoint
 	Hash       string // This is more of a connection ID than hash right now.
 
 	stopper sync.Once
 	stop    chan bool
 
-	lastPeerRequest  time.Time
-	peerShareAsk     bool
-	peerShareDeliver chan *Parcel
-	lastPeerSend     time.Time
+	lastPeerRequest time.Time
+	lastPeerSend    time.Time
 
 	// communication channels
-	send       ParcelChannel   // parcels from Send() are added here
-	status     chan peerStatus // the controller's notification channel
-	data       chan peerParcel // the controller's data channel
-	registered bool
+	send ParcelChannel // parcels from Send() are added here
 
 	// Metrics
 	metricsMtx           sync.RWMutex
@@ -60,156 +50,34 @@ type Peer struct {
 	logger *log.Entry
 }
 
-func newPeer(net *Network, status chan peerStatus, data chan peerParcel) *Peer {
-	p := &Peer{}
+func newPeer(net *Network, id uint32, ep Endpoint, conn net.Conn, protocol Protocol, metrics ReadWriteCollector, incoming bool) *Peer {
+	p := new(Peer)
 	p.net = net
-	p.status = status
-	p.data = data
+	p.prot = protocol
+	p.Endpoint = ep
+	p.metrics = metrics
+	p.conn = conn
+
+	p.stop = make(chan bool, 1)
+	p.Hash = fmt.Sprintf("%s:%s %08x", ep.IP, ep.Port, id)
 
 	p.logger = peerLogger.WithFields(log.Fields{
-		"node": net.conf.NodeName,
-	})
-	p.stop = make(chan bool, 1)
-
-	p.peerShareDeliver = nil
-
-	p.logger.Debugf("Creating blank peer")
-	return p
-}
-
-func (p *Peer) bootstrapProtocol(hs *Handshake, conn net.Conn, decoder *gob.Decoder, encoder *gob.Encoder) error {
-	v := hs.Header.Version
-	if v > p.net.conf.ProtocolVersion {
-		v = p.net.conf.ProtocolVersion
-	}
-
-	///fmt.Printf("@@@ %d %+v %s\n", v, hs.Header, conn.RemoteAddr())
-	switch v {
-	case 9:
-		v9 := new(ProtocolV9)
-		v9.init(p, decoder, encoder)
-		p.prot = v9
-
-		// v9 starts with a peer request
-		hsParcel := new(Parcel)
-		hsParcel.Address = hs.Header.TargetPeer
-		hsParcel.Payload = hs.Payload
-		hsParcel.Type = TypePeerRequest
-		/*	TODO at this point, peer is not fully initialized
-			if !p.deliver(hsParcel) {
-				return fmt.Errorf("unable to deliver peer request to controller")
-			}*/
-	case 10:
-		v10 := new(ProtocolV10)
-		v10.init(p, decoder, encoder)
-		p.prot = v10
-	default:
-		return fmt.Errorf("unknown protocol version %d", v)
-	}
-	return nil
-}
-
-// StartWithHandshake performs a basic handshake maneouver to establish the validity
-// of the connection. Immediately sends a Peer Request upon connection and waits for the
-// response, which can be any parcel. The information in the header is verified, especially
-// the port.
-//
-// The handshake ensures that ALL peers have a valid Port field to start with.
-// If there is no reply within the specified HandshakeTimeout config setting, the process
-// fails
-//
-// For outgoing connections, it is possible the endpoint will reject due to being full, in which
-// case this function returns an error AND a list of alternate endpoints
-func (p *Peer) StartWithHandshake(ep Endpoint, con net.Conn, incoming bool) ([]Endpoint, error) {
-	tmplogger := p.logger.WithField("addr", ep.IP)
-	timeout := time.Now().Add(p.net.conf.HandshakeTimeout)
-
-	nonce := make([]byte, 8)
-	binary.LittleEndian.PutUint64(nonce, p.net.instanceID)
-
-	// upgrade connection to a metrics connection
-	p.metrics = NewMetricsReadWriter(con)
-	p.conn = con
-
-	handshake := newHandshake(p.net.conf, nonce)
-	decoder := gob.NewDecoder(p.metrics) // pipe gob through the metrics writer
-	encoder := gob.NewEncoder(p.metrics)
-	con.SetWriteDeadline(timeout)
-	con.SetReadDeadline(timeout)
-	//fmt.Printf("@@@ %+v %s\n", handshake.Header, con.RemoteAddr())
-
-	failfunc := func(err error) ([]Endpoint, error) {
-		tmplogger.WithError(err).Debug("Handshake failed")
-		p.conn.Close()
-		return nil, err
-	}
-
-	err := encoder.Encode(handshake)
-	if err != nil {
-		return failfunc(fmt.Errorf("Failed to send handshake to incoming connection"))
-	}
-
-	var reply Handshake
-	err = decoder.Decode(&reply)
-	if err != nil {
-		return failfunc(fmt.Errorf("Failed to read handshake from incoming connection"))
-	}
-
-	// check basic structure
-	if err = reply.Valid(p.net.conf); err != nil {
-		return failfunc(err)
-	}
-
-	// loopback detection
-	if bytes.Equal(reply.Payload, nonce) {
-		return failfunc(fmt.Errorf("loopback"))
-	}
-
-	if err = p.bootstrapProtocol(&reply, con, decoder, encoder); err != nil {
-		return failfunc(err)
-	}
-
-	if reply.Header.Type == TypeRejectAlternative {
-		con.Close()
-		tmplogger.Debug("con rejected with alternatives")
-		var rawShare []Endpoint
-		err := json.Unmarshal(reply.Payload, &rawShare)
-		if err != nil {
-			return nil, fmt.Errorf("unable to parse alternatives: %s", err.Error())
-		}
-
-		filtered := make([]Endpoint, 0, len(rawShare))
-		for _, ep := range rawShare {
-			if ep.Valid() {
-				filtered = append(filtered, ep)
-			}
-		}
-		return filtered, fmt.Errorf("connection rejected")
-	}
-
-	// initialize channels
-	ep.Port = reply.Header.PeerPort
-	p.Endpoint = ep
-	p.NodeID = uint32(reply.Header.NodeID)
-	p.Hash = fmt.Sprintf("%s:%s %08x", ep.IP, ep.Port, p.NodeID)
-	p.send = newParcelChannel(p.net.conf.ChannelCapacity)
-	p.IsIncoming = incoming
-	p.connected = time.Now()
-	p.logger = p.logger.WithFields(log.Fields{
 		"hash":    p.Hash,
 		"address": p.Endpoint.IP,
 		"Port":    p.Endpoint.Port,
 		"Version": p.prot.Version(),
 	})
 
-	p.status <- peerStatus{peer: p, online: true}
-	p.registered = true
+	// initialize channels
+	p.send = newParcelChannel(p.net.conf.ChannelCapacity)
+	p.IsIncoming = incoming
+	p.connected = time.Now()
 
 	go p.sendLoop()
 	go p.readLoop()
 	go p.statLoop()
 
-	return nil, nil
+	return p
 }
 
 // Stop disconnects the peer from its active connection
@@ -230,9 +98,7 @@ func (p *Peer) Stop() {
 			close(sc)
 		}
 
-		if p.registered {
-			p.status <- peerStatus{peer: p, online: false}
-		}
+		p.net.controller.peerStatus <- peerStatus{peer: p, online: false}
 	})
 }
 
@@ -317,7 +183,7 @@ func (p *Peer) readLoop() {
 // deliver is a blocking delivery of this peer's messages to the peer manager.
 func (p *Peer) deliver(parcel *Parcel) bool {
 	select {
-	case p.data <- peerParcel{peer: p, parcel: parcel}:
+	case p.net.controller.peerData <- peerParcel{peer: p, parcel: parcel}:
 	case <-p.stop:
 		return false
 	}
@@ -359,7 +225,7 @@ func (p *Peer) sendLoop() {
 			// stats
 			if p.net.prom != nil {
 				p.net.prom.ParcelsSent.Inc()
-				p.net.prom.ParcelSize.Observe(float64(len(parcel.Payload)+32) / 1024) // TODO FIX
+				p.net.prom.ParcelSize.Observe(float64(len(parcel.Payload)+32) / 1024)
 				if parcel.IsApplicationMessage() {
 					p.net.prom.AppSent.Inc()
 				}

--- a/protocolV10.go
+++ b/protocolV10.go
@@ -12,10 +12,8 @@ var _ Protocol = (*ProtocolV10)(nil)
 // ProtocolV10 is the protocol introduced by p2p 2.0.
 // It is a slimmed down version of V9, reducing overhead
 type ProtocolV10 struct {
-	net     *Network
 	decoder *gob.Decoder
 	encoder *gob.Encoder
-	peer    *Peer
 }
 
 // V10Msg is the barebone message
@@ -25,9 +23,7 @@ type V10Msg struct {
 	Payload []byte
 }
 
-func (v10 *ProtocolV10) init(peer *Peer, decoder *gob.Decoder, encoder *gob.Encoder) {
-	v10.peer = peer
-	v10.net = peer.net
+func (v10 *ProtocolV10) init(decoder *gob.Decoder, encoder *gob.Encoder) {
 	v10.decoder = decoder
 	v10.encoder = encoder
 }

--- a/protocolV9.go
+++ b/protocolV9.go
@@ -17,12 +17,10 @@ type ProtocolV9 struct {
 	net     *Network
 	decoder *gob.Decoder
 	encoder *gob.Encoder
-	peer    *Peer
 }
 
-func (v9 *ProtocolV9) init(peer *Peer, decoder *gob.Decoder, encoder *gob.Encoder) {
-	v9.peer = peer
-	v9.net = peer.net
+func (v9 *ProtocolV9) init(net *Network, decoder *gob.Decoder, encoder *gob.Encoder) {
+	v9.net = net
 	v9.decoder = decoder
 	v9.encoder = encoder
 }


### PR DESCRIPTION
This is a PR to address some of the issues mentioned in #22:

* The Peer object is now initialized after the handshake is complete, meaning a peer only has the state of being a valid connection
* The controller is now responsible for handshakes
* Peer struct has been cleaned up to remove unused variables
* Banned or rejected endpoints won't instantiate a peer

Overall, I think it cleared up some of the awkward program flow regarding peers having to register themselves with the controller or having to Stop() peers right after initialization