### PR TITLE
Routing Improvements

### DIFF
--- a/controller_cat.go
+++ b/controller_cat.go
@@ -205,13 +205,12 @@ func (c *controller) catReplenish() {
 		}
 
 		if c.peers.Total() > 0 {
-			rand := c.randomPeersConditional(1, func(p *Peer) bool {
+			rand := c.randomPeerConditional(func(p *Peer) bool {
 				return time.Since(p.lastPeerSend) >= c.net.conf.PeerRequestInterval
 			})
-			if len(rand) > 0 {
-				p := rand[0]
+			if rand != nil {
 				// error just means timeout of async request
-				if eps, err := c.asyncPeerRequest(p); err == nil {
+				if eps, err := c.asyncPeerRequest(rand); err == nil {
 					// pick random share from peer
 					if len(eps) > 0 {
 						el := c.net.rng.Intn(len(eps))

--- a/controller_routing.go
+++ b/controller_routing.go
@@ -88,13 +88,13 @@ func (c *controller) manageData() {
 	}
 }
 
-func (c *controller) randomPeers(count uint) []*Peer {
+func (c *controller) randomPeers(max uint) []*Peer {
 	peers := c.peers.Slice()
 	if len(peers) == 0 {
 		return nil
 	}
 	// not enough to randomize
-	if uint(len(peers)) <= count {
+	if uint(len(peers)) <= max {
 		return peers
 	}
 
@@ -102,10 +102,10 @@ func (c *controller) randomPeers(count uint) []*Peer {
 		peers[i], peers[j] = peers[j], peers[i]
 	})
 
-	return peers[:count]
+	return peers[:max]
 }
 
-func (c *controller) randomPeersConditional(count uint, condition func(*Peer) bool) []*Peer {
+func (c *controller) randomPeersConditional(max uint, condition func(*Peer) bool) []*Peer {
 	peers := c.peers.Slice()
 	if len(peers) == 0 {
 		return nil
@@ -118,7 +118,7 @@ func (c *controller) randomPeersConditional(count uint, condition func(*Peer) bo
 		}
 	}
 	// not enough to randomize
-	if len(filtered) <= int(count) {
+	if len(filtered) <= int(max) {
 		return filtered
 	}
 
@@ -126,7 +126,7 @@ func (c *controller) randomPeersConditional(count uint, condition func(*Peer) bo
 		filtered[i], filtered[j] = filtered[j], filtered[i]
 	})
 
-	return filtered[:count]
+	return filtered[:max]
 }
 
 func (c *controller) randomPeer() *Peer {
@@ -137,11 +137,11 @@ func (c *controller) randomPeer() *Peer {
 	return nil
 }
 
-func (c *controller) selectBroadcastPeers(count uint) []*Peer {
+func (c *controller) selectBroadcastPeers(max uint) []*Peer {
 	peers := c.peers.Slice()
 
 	// not enough to randomize
-	if uint(len(peers)) <= count {
+	if uint(len(peers)) <= max {
 		return peers
 	}
 
@@ -156,7 +156,7 @@ func (c *controller) selectBroadcastPeers(count uint) []*Peer {
 		}
 	}
 
-	if uint(len(regular)) < count {
+	if uint(len(regular)) < max {
 		return append(special, regular...)
 	}
 
@@ -164,5 +164,5 @@ func (c *controller) selectBroadcastPeers(count uint) []*Peer {
 		regular[i], regular[j] = regular[j], regular[i]
 	})
 
-	return append(special, regular[:count]...)
+	return append(special, regular[:max]...)
 }

--- a/controller_routing.go
+++ b/controller_routing.go
@@ -88,21 +88,7 @@ func (c *controller) manageData() {
 	}
 }
 
-func (c *controller) randomPeers(max uint) []*Peer {
-	peers := c.peers.Slice()
-	// not enough to randomize
-	if uint(len(peers)) <= max {
-		return peers
-	}
-
-	c.net.rng.Shuffle(len(peers), func(i, j int) {
-		peers[i], peers[j] = peers[j], peers[i]
-	})
-
-	return peers[:max]
-}
-
-func (c *controller) randomPeersConditional(max uint, condition func(*Peer) bool) []*Peer {
+func (c *controller) randomPeerConditional(condition func(*Peer) bool) *Peer {
 	peers := c.peers.Slice()
 
 	filtered := make([]*Peer, 0)
@@ -111,22 +97,17 @@ func (c *controller) randomPeersConditional(max uint, condition func(*Peer) bool
 			filtered = append(filtered, p)
 		}
 	}
-	// not enough to randomize
-	if len(filtered) <= int(max) {
-		return filtered
+
+	if len(filtered) > 0 {
+		return filtered[c.net.rng.Intn(len(filtered))]
 	}
-
-	c.net.rng.Shuffle(len(filtered), func(i, j int) {
-		filtered[i], filtered[j] = filtered[j], filtered[i]
-	})
-
-	return filtered[:max]
+	return nil
 }
 
 func (c *controller) randomPeer() *Peer {
-	peers := c.randomPeers(1)
-	if len(peers) == 1 {
-		return peers[0]
+	peers := c.peers.Slice()
+	if len(peers) > 0 {
+		return peers[c.net.rng.Intn(len(peers))]
 	}
 	return nil
 }

--- a/controller_routing.go
+++ b/controller_routing.go
@@ -20,9 +20,7 @@ func (c *controller) route() {
 					p.Send(parcel)
 				}
 
-			case "":
-				fallthrough
-			case RandomPeer:
+			case "", RandomPeer:
 				if random := c.randomPeer(); random != nil {
 					random.Send(parcel)
 				} else {
@@ -61,10 +59,7 @@ func (c *controller) manageData() {
 					parcel := newParcel(TypePong, []byte("Pong"))
 					peer.Send(parcel)
 				}()
-			case TypeMessage:
-				//c.net.FromNetwork.Send(parcel)
-				fallthrough
-			case TypeMessagePart:
+			case TypeMessage, TypeMessagePart:
 				parcel.Type = TypeMessage
 				c.net.FromNetwork.Send(parcel)
 			case TypePeerRequest:

--- a/controller_routing.go
+++ b/controller_routing.go
@@ -90,9 +90,6 @@ func (c *controller) manageData() {
 
 func (c *controller) randomPeers(max uint) []*Peer {
 	peers := c.peers.Slice()
-	if len(peers) == 0 {
-		return nil
-	}
 	// not enough to randomize
 	if uint(len(peers)) <= max {
 		return peers
@@ -107,9 +104,6 @@ func (c *controller) randomPeers(max uint) []*Peer {
 
 func (c *controller) randomPeersConditional(max uint, condition func(*Peer) bool) []*Peer {
 	peers := c.peers.Slice()
-	if len(peers) == 0 {
-		return nil
-	}
 
 	filtered := make([]*Peer, 0)
 	for _, p := range peers {

--- a/controller_routing.go
+++ b/controller_routing.go
@@ -112,11 +112,11 @@ func (c *controller) randomPeer() *Peer {
 	return nil
 }
 
-func (c *controller) selectBroadcastPeers(max uint) []*Peer {
+func (c *controller) selectBroadcastPeers(fanout uint) []*Peer {
 	peers := c.peers.Slice()
 
 	// not enough to randomize
-	if uint(len(peers)) <= max {
+	if uint(len(peers)) <= fanout {
 		return peers
 	}
 
@@ -131,7 +131,7 @@ func (c *controller) selectBroadcastPeers(max uint) []*Peer {
 		}
 	}
 
-	if uint(len(regular)) < max {
+	if uint(len(regular)) < fanout {
 		return append(special, regular...)
 	}
 
@@ -139,5 +139,5 @@ func (c *controller) selectBroadcastPeers(max uint) []*Peer {
 		regular[i], regular[j] = regular[j], regular[i]
 	})
 
-	return append(special, regular[:max]...)
+	return append(special, regular[:fanout]...)
 }


### PR DESCRIPTION
PR regarding various points in #28:

* Change randomPeers / randomPeersConditional to be more inline with their use-cases, now just randomPeer and randomPeerConditional
* Remove controller.ToPeer/Broadcast functions, now handled directly
* Rename 'count' to 'fanout' in selectBroadcastPeers