### PR TITLE
refactor: minor renaming, comments addition

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -59,8 +59,8 @@ type Configuration struct {
 	// Amount of peers to drop down to
 	DropTo uint
 	// Reseed if there are fewer than this peers
-	MinReseed uint
-	Incoming  uint // maximum inbound connections, 0 <= Incoming <= Max
+	MinReseed   uint
+	MaxIncoming uint // maximum inbound connections, 0 <= MaxIncoming <= MaxPeers
 
 	// === Gossip Behavior ===
 
@@ -134,7 +134,7 @@ func DefaultP2PConfiguration() (c Configuration) {
 	c.PeerCacheFile = ""
 	c.PeerCacheAge = time.Hour //
 
-	c.Incoming = 36
+	c.MaxIncoming = 36
 	c.Fanout = 8
 	c.PeerShareAmount = 3 // CAT share
 	c.RoundTime = time.Minute * 15
@@ -165,7 +165,7 @@ func DefaultP2PConfiguration() (c Configuration) {
 
 // Sanitize automatically adjusts some variables that are dependent on others
 func (c *Configuration) Sanitize() {
-	if c.Incoming > c.MaxPeers {
-		c.Incoming = c.MaxPeers
+	if c.MaxIncoming > c.MaxPeers {
+		c.MaxIncoming = c.MaxPeers
 	}
 }

--- a/controller_persistence.go
+++ b/controller_persistence.go
@@ -40,7 +40,7 @@ func (c *controller) loadPeerCacheFile() ([]byte, error) {
 	return ioutil.ReadFile(c.net.conf.PeerCacheFile)
 }
 
-func (c *controller) persistData() ([]byte, error) {
+func (c *controller) peerCacheData() ([]byte, error) {
 	var pers PeerCache
 	pers.Bans = make(map[string]time.Time)
 
@@ -85,13 +85,13 @@ func (c *controller) persistPeerFile() {
 		return
 	}
 
-	data, err := c.persistData()
+	data, err := c.peerCacheData()
 	if err != nil {
-		c.logger.WithError(err).Warn("unable to create peer persist data")
+		c.logger.WithError(err).Warn("unable to create peer cache data")
 	} else {
 		err = c.writePeerCacheFile(data)
 		if err != nil {
-			c.logger.WithError(err).Warn("unable to persist peer data")
+			c.logger.WithError(err).Warn("unable to persist peer cache data")
 		}
 	}
 }

--- a/dialer.go
+++ b/dialer.go
@@ -11,7 +11,7 @@ import (
 type Dialer struct {
 	dialer      net.Dialer
 	bindTo      string
-	interval    time.Duration
+	interval    time.Duration // Minimum duration enforced between two dial attempts
 	timeout     time.Duration
 	attempts    map[Endpoint]time.Time
 	attemptsMtx sync.RWMutex

--- a/limiter.go
+++ b/limiter.go
@@ -12,15 +12,15 @@ type LimitedListener struct {
 	listener       net.Listener
 	limit          time.Duration
 	lastConnection time.Time
-	history        []limitedConnect
+	history        []connection
 }
 
-type limitedConnect struct {
-	address string
-	time    time.Time
+type connection struct {
+	host string
+	time time.Time
 }
 
-// NewLimitedListener initializes a new listener for the specified address (address:port)
+// NewLimitedListener initializes a new listener for the specified address (host:port)
 // throttling incoming connections
 func NewLimitedListener(address string, limit time.Duration) (*LimitedListener, error) {
 	if limit < 0 {
@@ -64,13 +64,13 @@ func (ll *LimitedListener) clearHistory() {
 	}
 }
 
-// isInHistory checks if an address has connected in the last X seconds
+// isInHistory checks if a host (IP) has connected in the last X seconds
 // clears history before checking
-func (ll *LimitedListener) isInHistory(addr string) bool {
+func (ll *LimitedListener) isInHistory(host string) bool {
 	ll.clearHistory()
 
 	for _, h := range ll.history {
-		if h.address == addr {
+		if h.host == host {
 			return true
 		}
 	}
@@ -78,8 +78,8 @@ func (ll *LimitedListener) isInHistory(addr string) bool {
 }
 
 // addToHistory adds an address to the system at the current time
-func (ll *LimitedListener) addToHistory(addr string) {
-	ll.history = append(ll.history, limitedConnect{address: addr, time: time.Now()})
+func (ll *LimitedListener) addToHistory(host string) {
+	ll.history = append(ll.history, connection{host: host, time: time.Now()})
 	ll.lastConnection = time.Now()
 }
 
@@ -92,18 +92,18 @@ func (ll *LimitedListener) Accept() (net.Conn, error) {
 		return nil, err
 	}
 
-	addr, _, err := net.SplitHostPort(con.RemoteAddr().String())
+	host, _, err := net.SplitHostPort(con.RemoteAddr().String())
 	if err != nil {
 		con.Close()
 		return nil, err
 	}
 
-	if ll.isInHistory(addr) {
+	if ll.isInHistory(host) {
 		con.Close()
-		return nil, fmt.Errorf("connection rate limit exceeded for %s", addr)
+		return nil, fmt.Errorf("connection rate limit exceeded for %s", host)
 	}
 
-	ll.addToHistory(addr)
+	ll.addToHistory(host)
 	return con, nil
 }
 

--- a/limiter.go
+++ b/limiter.go
@@ -12,10 +12,10 @@ type LimitedListener struct {
 	listener       net.Listener
 	limit          time.Duration
 	lastConnection time.Time
-	history        []connection
+	history        []attempt
 }
 
-type connection struct {
+type attempt struct {
 	host string
 	time time.Time
 }
@@ -79,7 +79,7 @@ func (ll *LimitedListener) isInHistory(host string) bool {
 
 // addToHistory adds an address to the system at the current time
 func (ll *LimitedListener) addToHistory(host string) {
-	ll.history = append(ll.history, connection{host: host, time: time.Now()})
+	ll.history = append(ll.history, attempt{host: host, time: time.Now()})
 	ll.lastConnection = time.Now()
 }
 

--- a/limiter_test.go
+++ b/limiter_test.go
@@ -49,14 +49,14 @@ func TestNewLimitedListener(t *testing.T) {
 }
 
 func createLLHistory() *LimitedListener {
-	past := connection{"past", time.Now().Add(time.Hour * -2)}
-	presence := connection{"presence", time.Now()}
-	future := connection{"future", time.Now().Add(time.Hour * 2)}
+	past := attempt{"past", time.Now().Add(time.Hour * -2)}
+	presence := attempt{"presence", time.Now()}
+	future := attempt{"future", time.Now().Add(time.Hour * 2)}
 	return &LimitedListener{
 		listener:       nil,
 		limit:          time.Hour,
 		lastConnection: time.Now(),
-		history:        []connection{past, presence, future}, // order matters, old < new
+		history:        []attempt{past, presence, future}, // order matters, old < new
 	}
 }
 

--- a/limiter_test.go
+++ b/limiter_test.go
@@ -49,14 +49,14 @@ func TestNewLimitedListener(t *testing.T) {
 }
 
 func createLLHistory() *LimitedListener {
-	past := limitedConnect{"past", time.Now().Add(time.Hour * -2)}
-	presence := limitedConnect{"presence", time.Now()}
-	future := limitedConnect{"future", time.Now().Add(time.Hour * 2)}
+	past := connection{"past", time.Now().Add(time.Hour * -2)}
+	presence := connection{"presence", time.Now()}
+	future := connection{"future", time.Now().Add(time.Hour * 2)}
 	return &LimitedListener{
 		listener:       nil,
 		limit:          time.Hour,
 		lastConnection: time.Now(),
-		history:        []limitedConnect{past, presence, future}, // order matters, old < new
+		history:        []connection{past, presence, future}, // order matters, old < new
 	}
 }
 

--- a/peerStore.go
+++ b/peerStore.go
@@ -24,7 +24,7 @@ func NewPeerStore() *PeerStore {
 	return ps
 }
 
-// Add a peer to be managed. Throws error if a peer with that hash
+// Add a peer to be managed. Returns an error if a peer with that hash
 // is already tracked
 func (ps *PeerStore) Add(p *Peer) error {
 	if p == nil {
@@ -32,8 +32,8 @@ func (ps *PeerStore) Add(p *Peer) error {
 	}
 	ps.mtx.Lock()
 	defer ps.mtx.Unlock()
-	_, ok := ps.peers[p.Hash]
-	if ok {
+
+	if _, ok := ps.peers[p.Hash]; ok {
 		return fmt.Errorf("peer already exists")
 	}
 	ps.curSlice = nil


### PR DESCRIPTION
Some minor refactoring I was accumulating while finishing the review. The main one may be that it seems you were using `address` interchangeably with `host/IP` sometimes, mostly in the connection limiter, so I just renamed address to host to make it more clear the rate limiting was applied at the IP/host level and not IP+port (=address).