### PR TITLE
Use thread safe RNG source

### DIFF
--- a/lockSource.go
+++ b/lockSource.go
@@ -1,0 +1,44 @@
+package p2p
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+)
+
+// golang's rand.Rand instances are not thread safe
+// this wraps the unsafe functions in a mutex
+type lockSource struct {
+	src rand.Source64
+	mtx sync.Mutex
+}
+
+func newLockSource(seed int64) (*lockSource, error) {
+	src, ok := rand.NewSource(seed).(rand.Source64)
+	if !ok {
+		return nil, fmt.Errorf("golang version incompatibility, expected math/ran.NewSource to be Source64")
+	}
+	ls := new(lockSource)
+	ls.src = src
+	return ls, nil
+}
+
+func (r *lockSource) Int63() (n int64) {
+	r.mtx.Lock()
+	n = r.src.Int63()
+	r.mtx.Unlock()
+	return
+}
+
+func (r *lockSource) Uint64() (n uint64) {
+	r.mtx.Lock()
+	n = r.src.Uint64()
+	r.mtx.Unlock()
+	return
+}
+
+func (r *lockSource) Seed(seed int64) {
+	r.mtx.Lock()
+	r.src.Seed(seed)
+	r.mtx.Unlock()
+}

--- a/lockSource_test.go
+++ b/lockSource_test.go
@@ -1,0 +1,33 @@
+package p2p
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func Test_LockSource(t *testing.T) {
+
+	rng := rand.New(rand.NewSource(1))
+	src, err := newLockSource(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	myrng := rand.New(src)
+
+	for i := 0; i < 1000; i++ {
+		a := rng.Uint64()
+		b := myrng.Uint64()
+		if a != b {
+			t.Errorf("Uint64() mismatch in iteration %d: want = %d, got = %d", i, a, b)
+		}
+	}
+
+	for i := 0; i < 1000; i++ {
+		a := rng.Int63()
+		b := myrng.Int63()
+		if a != b {
+			t.Errorf("Int63() mismatch in iteration %d: want = %d, got = %d", i, a, b)
+		}
+	}
+
+}


### PR DESCRIPTION
Stumbled across this while using the race detector. Since the network has its own RNG instance, we need to ensure it is thread safe.