### PR TITLE
Race condition cleanup

### DIFF
--- a/controller_run.go
+++ b/controller_run.go
@@ -25,7 +25,7 @@ func (c *controller) run() {
 // a specific duration has passed
 func (c *controller) runPing() {
 	for _, p := range c.peers.Slice() {
-		if time.Since(p.lastSend) > c.net.conf.PingInterval {
+		if p.LastSendAge() > c.net.conf.PingInterval {
 			ping := newParcel(TypePing, []byte("Ping"))
 			p.Send(ping)
 		}

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,7 @@ github.com/prometheus/client_golang v1.2.1 h1:JnMpQc6ppsNgw9QPAGF6Dod479itz7lvls
 github.com/prometheus/client_golang v1.2.1/go.mod h1:XMU6Z2MjaRKVu/dC1qupJI9SiNkDYzz3xecMgSW/F+U=
 github.com/prometheus/client_golang v1.3.0 h1:miYCvYqFXtl/J9FIy8eNpBfYthAEFg+Ys0XyUVEcDsc=
 github.com/prometheus/client_golang v1.4.0 h1:YVIb/fVcOTMSqtqZWSKnHpSLBxu8DKgxq8z6RuBZwqI=
+github.com/prometheus/client_golang v1.4.1 h1:FFSuS004yOQEtDdTq+TAOLP5xUq63KqAFYyOi8zA+Y8=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 h1:gQz4mCbXsO+nc9n1hCxHcGA3Zx3Eo+UHZoInFGUIXNM=

--- a/metricsReadWriter.go
+++ b/metricsReadWriter.go
@@ -48,13 +48,9 @@ func (sc *MetricsReadWriter) Read(p []byte) (int, error) {
 }
 
 func (sc *MetricsReadWriter) Collect() (mw uint64, mr uint64, bw uint64, br uint64) {
-	mw = sc.messagesWritten
-	sc.messagesWritten = 0
-	mr = sc.messagesRead
-	sc.messagesRead = 0
-	bw = sc.bytesWritten
-	sc.bytesWritten = 0
-	br = sc.bytesRead
-	sc.bytesRead = 0
+	mw = atomic.SwapUint64(&sc.messagesWritten, 0)
+	mr = atomic.SwapUint64(&sc.messagesRead, 0)
+	bw = atomic.SwapUint64(&sc.bytesWritten, 0)
+	br = atomic.SwapUint64(&sc.bytesRead, 0)
 	return
 }

--- a/peerStore.go
+++ b/peerStore.go
@@ -131,11 +131,14 @@ func (ps *PeerStore) Count(addr string) int {
 // ordered
 func (ps *PeerStore) Slice() []*Peer {
 	ps.mtx.RLock()
-	defer ps.mtx.RUnlock()
-
 	if ps.curSlice != nil {
+		defer ps.mtx.RUnlock()
 		return append(ps.curSlice[:0:0], ps.curSlice...)
 	}
+	ps.mtx.RUnlock()
+
+	ps.mtx.Lock()
+	defer ps.mtx.Unlock()
 	r := make([]*Peer, 0, len(ps.peers))
 	for _, p := range ps.peers {
 		r = append(r, p)


### PR DESCRIPTION
The race conditions reported by golang's race tester ended up being all benign but I wanted to clean them up to make any future race testing easier, and avoid oddities in the future

* Don't access peer.lastSend directly from controller, pass through mutex
* Use atomic counterparts for the metric collection
* Rework peer stop function to properly close the send channel rather than setting it to nil
* Don't update the PeerStore's slice cache in a read-mutex