### PR TITLE
Ability to stop a network

### DIFF
--- a/controller_cat.go
+++ b/controller_cat.go
@@ -171,6 +171,12 @@ func (c *controller) catReplenish() {
 	lastReseed := time.Now()
 
 	for {
+		select {
+		case <-c.net.stopper:
+			return
+		default:
+		}
+
 		var connect []Endpoint
 		if uint(c.peers.Total()) >= c.net.conf.TargetPeers {
 			time.Sleep(time.Second)

--- a/controller_connections.go
+++ b/controller_connections.go
@@ -20,8 +20,6 @@ func (c *controller) manageOnline() {
 	defer c.logger.Debug("Stop manageOnline()")
 	for {
 		select {
-		case <-c.net.stopper:
-			return
 		case pc := <-c.peerStatus:
 			if pc.online {
 				if old := c.peers.Get(pc.peer.Hash); old != nil {
@@ -42,6 +40,9 @@ func (c *controller) manageOnline() {
 				c.net.prom.Incoming.Set(float64(c.peers.Incoming()))
 				c.net.prom.Outgoing.Set(float64(c.peers.Outgoing()))
 			}
+		case <-c.net.stopper:
+			// ordered second so that manageOnline will clear out all peers from the peer store first
+			return
 		}
 	}
 }
@@ -297,8 +298,13 @@ func (c *controller) listen() {
 		tmpLogger.WithError(err).Error("controller.Start() unable to start limited listener")
 		return
 	}
-
+	defer tmpLogger.Debug("controller.listen() stopping")
 	c.listener = l
+
+	go func() { // the listener doesn't play well with immediately stopping
+		<-c.net.stopper
+		c.listener.Close()
+	}()
 
 	// start permanent loop
 	// terminates on program exit or when listener is closed
@@ -307,7 +313,8 @@ func (c *controller) listen() {
 		if err != nil {
 			if ne, ok := err.(*net.OpError); ok && !ne.Timeout() {
 				if !ne.Temporary() {
-					tmpLogger.WithError(err).Warn("controller.acceptLoop() error accepting")
+					tmpLogger.WithError(err).Error("controller.acceptLoop() error accepting")
+					return
 				}
 			}
 			continue

--- a/controller_connections.go
+++ b/controller_connections.go
@@ -20,6 +20,8 @@ func (c *controller) manageOnline() {
 	defer c.logger.Debug("Stop manageOnline()")
 	for {
 		select {
+		case <-c.net.stopper:
+			return
 		case pc := <-c.peerStatus:
 			if pc.online {
 				if old := c.peers.Get(pc.peer.Hash); old != nil {

--- a/controller_connections.go
+++ b/controller_connections.go
@@ -300,6 +300,11 @@ func (c *controller) listen() {
 	defer tmpLogger.Debug("controller.listen() stopping")
 	c.listener = l
 
+	go func() { // the listener doesn't play well with immediately stopping
+		<-c.net.stopper
+		c.listener.Close()
+	}()
+
 	// start permanent loop
 	// terminates on program exit or when listener is closed
 	for {

--- a/controller_connections.go
+++ b/controller_connections.go
@@ -41,7 +41,6 @@ func (c *controller) manageOnline() {
 				c.net.prom.Outgoing.Set(float64(c.peers.Outgoing()))
 			}
 		case <-c.net.stopper:
-			// ordered second so that manageOnline will clear out all peers from the peer store first
 			return
 		}
 	}
@@ -300,11 +299,6 @@ func (c *controller) listen() {
 	}
 	defer tmpLogger.Debug("controller.listen() stopping")
 	c.listener = l
-
-	go func() { // the listener doesn't play well with immediately stopping
-		<-c.net.stopper
-		c.listener.Close()
-	}()
 
 	// start permanent loop
 	// terminates on program exit or when listener is closed

--- a/controller_routing.go
+++ b/controller_routing.go
@@ -4,9 +4,13 @@ import "time"
 
 // route takes messages from ToNetwork and routes it to the appropriate peers
 func (c *controller) route() {
+	c.logger.Debug("Start controller.route()")
+	defer c.logger.Debug("Start controller.route()")
 	for {
 		// blocking read on ToNetwork, and c.stopRoute
 		select {
+		case <-c.net.stopper:
+			return
 		case parcel := <-c.net.ToNetwork:
 			switch parcel.Address {
 			case FullBroadcast:
@@ -39,10 +43,12 @@ func (c *controller) route() {
 // manageData processes parcels arriving from peers and responds appropriately.
 // application messages are forwarded to the network channel.
 func (c *controller) manageData() {
-	c.logger.Debug("Start manageData()")
-	defer c.logger.Debug("Stop manageData()")
+	c.logger.Debug("Start controller.manageData()")
+	defer c.logger.Debug("Stop controller.manageData()")
 	for {
 		select {
+		case <-c.net.stopper:
+			return
 		case pp := <-c.peerData:
 			parcel := pp.parcel
 			peer := pp.peer

--- a/controller_routing.go
+++ b/controller_routing.go
@@ -5,7 +5,7 @@ import "time"
 // route takes messages from ToNetwork and routes it to the appropriate peers
 func (c *controller) route() {
 	c.logger.Debug("Start controller.route()")
-	defer c.logger.Debug("Start controller.route()")
+	defer c.logger.Debug("Stop controller.route()")
 	for {
 		// blocking read on ToNetwork, and c.stopRoute
 		select {

--- a/controller_run.go
+++ b/controller_run.go
@@ -16,6 +16,8 @@ func (c *controller) run() {
 		c.runPing()
 
 		select {
+		case <-c.net.stopper:
+			return
 		case <-time.After(time.Second):
 		}
 	}

--- a/network.go
+++ b/network.go
@@ -125,7 +125,6 @@ func (n *Network) Stop() error {
 		return fmt.Errorf("network already stopped")
 	default:
 		n.logger.Info("Network.Stop() called")
-		n.controller.listener.Close()
 		close(n.stopper)
 		return nil
 	}

--- a/network.go
+++ b/network.go
@@ -1,7 +1,9 @@
 package p2p
 
 import (
+	"fmt"
 	"math/rand"
+	"sync"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -27,8 +29,8 @@ type Network struct {
 	instanceID uint64
 	logger     *log.Entry
 
-	globalCloser chan interface{}
-	fatalError   chan error
+	stopper        chan interface{}
+	startStopMutex sync.Mutex
 }
 
 var packageLogger = log.WithField("package", "p2p")
@@ -42,7 +44,7 @@ func NewNetwork(conf Configuration) (*Network, error) {
 	n := new(Network)
 	n.conf = &conf
 	n.conf.Sanitize()
-	n.fatalError = make(chan error)
+	n.stopper = make(chan interface{})
 
 	n.logger = packageLogger.WithField("subpackage", "Network").WithField("node", n.conf.NodeName)
 
@@ -104,19 +106,33 @@ func (n *Network) SetMetricsHook(f func(pm map[string]PeerMetrics)) {
 }
 
 // Run starts the network.
-// Listens to incoming connections on the specified port
-// and connects to other peers
-func (n *Network) Run() {
-	n.logger.Infof("Starting a P2P Network with configuration %+v", n.conf)
+// Listens to incoming connections on the specified port and connects to other peers
+func (n *Network) Run() error {
+	select {
+	case <-n.stopper:
+		return fmt.Errorf("unable to restart a network that has been stopped")
+	default:
+		n.logger.Infof("Starting a P2P Network with configuration %+v", n.conf)
+		n.controller.Start()
+		return nil
+	}
 
-	n.controller.Start() // this will get peer manager ready to handle incoming connections
-	//DebugServer(n)
 }
 
-func (n *Network) Stop() {
-	// TODO implement
-	// close stop channel
-	// stop all peers
+// Stop shuts down the network
+// Note that the network object will become unusable after it is stopped
+func (n *Network) Stop() error {
+	select {
+	case <-n.stopper:
+		return fmt.Errorf("network not running")
+	default:
+		n.controller.listener.Close()
+		close(n.stopper)
+		for _, p := range n.controller.peers.Slice() {
+			p.Stop()
+		}
+		return nil
+	}
 }
 
 // Ban removes a peer as well as any other peer from that address

--- a/network.go
+++ b/network.go
@@ -3,7 +3,6 @@ package p2p
 import (
 	"fmt"
 	"math/rand"
-	"sync"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -29,8 +28,7 @@ type Network struct {
 	instanceID uint64
 	logger     *log.Entry
 
-	stopper        chan interface{}
-	startStopMutex sync.Mutex
+	stopper chan interface{}
 }
 
 var packageLogger = log.WithField("package", "p2p")
@@ -124,12 +122,10 @@ func (n *Network) Run() error {
 func (n *Network) Stop() error {
 	select {
 	case <-n.stopper:
-		return fmt.Errorf("network not running")
+		return fmt.Errorf("network already stopped")
 	default:
 		n.logger.Info("Network.Stop() called")
-		for _, p := range n.controller.peers.Slice() {
-			p.Stop()
-		}
+		n.controller.listener.Close()
 		close(n.stopper)
 		return nil
 	}

--- a/network.go
+++ b/network.go
@@ -126,11 +126,11 @@ func (n *Network) Stop() error {
 	case <-n.stopper:
 		return fmt.Errorf("network not running")
 	default:
-		n.controller.listener.Close()
-		close(n.stopper)
+		n.logger.Info("Network.Stop() called")
 		for _, p := range n.controller.peers.Slice() {
 			p.Stop()
 		}
+		close(n.stopper)
 		return nil
 	}
 }

--- a/peer.go
+++ b/peer.go
@@ -86,7 +86,6 @@ func (p *Peer) Stop() {
 		p.logger.Debug("Stopping peer")
 		close(p.stop) // stops sendLoop and readLoop and statLoop
 		// sendLoop closes p.conn and p.send in defer
-
 		p.net.controller.peerStatus <- peerStatus{peer: p, online: false}
 	})
 }


### PR DESCRIPTION
Now that most of the reworks have been done, I wanted to add the ability to stop the networks again. 
* All peers are stopped
* All permanent goroutines are closed

The only special case was the limited listener. It's possible to close the listener and stop the routine but if a network is stopped immediately after being started, there's a chance the listener might not be initialized yet. In order to remedy that, there's a goroutine inside the listener loop that will close the listener if the network is shut down.