### PR TITLE
Export + Prometheus Changes

### DIFF
--- a/controller_cat.go
+++ b/controller_cat.go
@@ -14,6 +14,9 @@ func (c *controller) runCatRound() {
 	c.lastRound = time.Now()
 	c.logger.Debug("Cat Round")
 	c.rounds++
+	if c.net.prom != nil {
+		c.net.prom.CatRounds.Inc()
+	}
 
 	c.persistPeerFile()
 

--- a/controller_connections.go
+++ b/controller_connections.go
@@ -36,7 +36,6 @@ func (c *controller) manageOnline() {
 			}
 			if c.net.prom != nil {
 				c.net.prom.Connections.Set(float64(c.peers.Total()))
-				//c.net.prom.Unique.Set(float64(c.peers.Unique()))
 				c.net.prom.Incoming.Set(float64(c.peers.Incoming()))
 				c.net.prom.Outgoing.Set(float64(c.peers.Outgoing()))
 			}

--- a/controller_routing.go
+++ b/controller_routing.go
@@ -59,14 +59,14 @@ func (c *controller) manageData() {
 			}
 
 			//c.logger.Debugf("Received parcel %s from %s", parcel, peer)
-			switch parcel.Type {
+			switch parcel.ptype {
 			case TypePing:
 				go func() {
 					parcel := newParcel(TypePong, []byte("Pong"))
 					peer.Send(parcel)
 				}()
 			case TypeMessage, TypeMessagePart:
-				parcel.Type = TypeMessage
+				parcel.ptype = TypeMessage
 				c.net.FromNetwork.Send(parcel)
 			case TypePeerRequest:
 				if time.Since(peer.lastPeerRequest) >= c.net.conf.PeerRequestInterval {

--- a/controller_routing.go
+++ b/controller_routing.go
@@ -11,7 +11,7 @@ func (c *controller) route() {
 		select {
 		case <-c.net.stopper:
 			return
-		case parcel := <-c.net.ToNetwork:
+		case parcel := <-c.net.toNetwork:
 			switch parcel.Address {
 			case FullBroadcast:
 				for _, p := range c.peers.Slice() {
@@ -67,7 +67,7 @@ func (c *controller) manageData() {
 				}()
 			case TypeMessage, TypeMessagePart:
 				parcel.ptype = TypeMessage
-				c.net.FromNetwork.Send(parcel)
+				c.net.fromNetwork.Send(parcel)
 			case TypePeerRequest:
 				if time.Since(peer.lastPeerRequest) >= c.net.conf.PeerRequestInterval {
 					peer.lastPeerRequest = time.Now()

--- a/controller_run.go
+++ b/controller_run.go
@@ -63,7 +63,7 @@ func (c *controller) runMetrics() {
 
 		c.net.prom.ToNetwork.Set(float64(len(c.net.toNetwork)))
 		c.net.prom.ToNetworkRatio.Set(c.net.toNetwork.FillRatio())
-		c.net.prom.FromNetwork.Set(float64(len(c.net.toNetwork)))
+		c.net.prom.FromNetwork.Set(float64(len(c.net.fromNetwork)))
 		c.net.prom.FromNetworkRatio.Set(c.net.fromNetwork.FillRatio())
 	}
 }

--- a/controller_run.go
+++ b/controller_run.go
@@ -61,7 +61,9 @@ func (c *controller) runMetrics() {
 		c.net.prom.MessageRateUp.Set(MPSUp)
 		c.net.prom.MessageRateDown.Set(MPSDown)
 
-		c.net.prom.ToNetworkRatio.Set(float64(len(c.net.toNetwork)) / float64(cap(c.net.toNetwork)))
-		c.net.prom.FromNetworkRatio.Set(float64(len(c.net.toNetwork)) / float64(cap(c.net.fromNetwork)))
+		c.net.prom.ToNetwork.Set(float64(len(c.net.toNetwork)))
+		c.net.prom.ToNetworkRatio.Set(c.net.toNetwork.FillRatio())
+		c.net.prom.FromNetwork.Set(float64(len(c.net.toNetwork)))
+		c.net.prom.FromNetworkRatio.Set(c.net.fromNetwork.FillRatio())
 	}
 }

--- a/debug.go
+++ b/debug.go
@@ -107,8 +107,8 @@ func DebugServer(n *Network) {
 	mux.HandleFunc("/stats", func(rw http.ResponseWriter, req *http.Request) {
 		out := ""
 		out += fmt.Sprintf("Channels\n")
-		out += fmt.Sprintf("\tToNetwork: %d / %d\n", len(n.ToNetwork), cap(n.ToNetwork))
-		out += fmt.Sprintf("\tFromNetwork: %d / %d\n", len(n.FromNetwork), cap(n.FromNetwork))
+		out += fmt.Sprintf("\tToNetwork: %d / %d\n", len(n.toNetwork), cap(n.toNetwork))
+		out += fmt.Sprintf("\tFromNetwork: %d / %d\n", len(n.fromNetwork), cap(n.fromNetwork))
 		out += fmt.Sprintf("\tpeerData: %d / %d\n", len(n.controller.peerData), cap(n.controller.peerData))
 		out += fmt.Sprintf("\nPeers (%d)\n", n.controller.peers.Total())
 

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,7 @@ github.com/prometheus/client_golang v1.2.1/go.mod h1:XMU6Z2MjaRKVu/dC1qupJI9SiNk
 github.com/prometheus/client_golang v1.3.0 h1:miYCvYqFXtl/J9FIy8eNpBfYthAEFg+Ys0XyUVEcDsc=
 github.com/prometheus/client_golang v1.4.0 h1:YVIb/fVcOTMSqtqZWSKnHpSLBxu8DKgxq8z6RuBZwqI=
 github.com/prometheus/client_golang v1.4.1 h1:FFSuS004yOQEtDdTq+TAOLP5xUq63KqAFYyOi8zA+Y8=
+github.com/prometheus/client_golang v1.5.0 h1:Ctq0iGpCmr3jeP77kbF2UxgvRwzWWz+4Bh9/vJTyg1A=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 h1:gQz4mCbXsO+nc9n1hCxHcGA3Zx3Eo+UHZoInFGUIXNM=

--- a/network.go
+++ b/network.go
@@ -171,7 +171,7 @@ func (n *Network) Send(p *Parcel) {
 	n.toNetwork.Send(p)
 }
 
-// BlockingSend accepts a parcel and sends it to the appropriate patries.
+// BlockingSend accepts a parcel and sends it to the appropriate parties.
 // This function blocks after the queue fills up.
 func (n *Network) BlockingSend(p *Parcel) {
 	n.toNetwork <- p

--- a/parcel.go
+++ b/parcel.go
@@ -25,14 +25,14 @@ var (
 //
 // The payload is arbitrary data defined at application level
 type Parcel struct {
-	Type    ParcelType // 2 bytes - network level commands (eg: ping/pong)
+	ptype   ParcelType // 2 bytes - network level commands (eg: ping/pong)
 	Address string     // ? bytes - "" or nil for broadcast, otherwise the destination peer's hash.
 	Payload []byte
 }
 
 // IsApplicationMessage checks if the message is intended for the application
 func (p *Parcel) IsApplicationMessage() bool {
-	switch p.Type {
+	switch p.ptype {
 	case TypeMessage, TypeMessagePart:
 		return true
 	default:
@@ -41,7 +41,7 @@ func (p *Parcel) IsApplicationMessage() bool {
 }
 
 func (p *Parcel) String() string {
-	return fmt.Sprintf("[%s] %dB", p.Type, len(p.Payload))
+	return fmt.Sprintf("[%s] %dB", p.ptype, len(p.Payload))
 }
 
 // NewParcel creates a new application message. The target should be either an identifier
@@ -54,7 +54,7 @@ func NewParcel(target string, payload []byte) *Parcel {
 
 func newParcel(command ParcelType, payload []byte) *Parcel {
 	parcel := new(Parcel)
-	parcel.Type = command
+	parcel.ptype = command
 	parcel.Payload = payload
 	return parcel
 }
@@ -65,8 +65,8 @@ func (p *Parcel) Valid() error {
 		return fmt.Errorf("nil parcel")
 	}
 
-	if p.Type >= ParcelType(len(typeStrings)) {
-		return fmt.Errorf("unknown parcel type %d", p.Type)
+	if p.ptype >= ParcelType(len(typeStrings)) {
+		return fmt.Errorf("unknown parcel type %d", p.ptype)
 	}
 
 	if len(p.Payload) == 0 {

--- a/parcel_test.go
+++ b/parcel_test.go
@@ -11,18 +11,18 @@ func TestParcel_Test(t *testing.T) {
 		app     bool
 	}{
 		{"blank parcel", &Parcel{}, true, false},
-		{"heartbeat", &Parcel{Type: TypeHeartbeat, Address: "", Payload: []byte{0}}, false, false},
-		{"empty payload", &Parcel{Type: TypeHeartbeat, Address: "", Payload: []byte{}}, true, false},
-		{"ping", &Parcel{Type: TypePing, Address: "", Payload: []byte{0}}, false, false},
-		{"pong", &Parcel{Type: TypePong, Address: "", Payload: []byte{0}}, false, false},
-		{"p request", &Parcel{Type: TypePeerRequest, Address: "", Payload: []byte{0}}, false, false},
-		{"p response", &Parcel{Type: TypePeerResponse, Address: "", Payload: []byte{0}}, false, false},
-		{"alert", &Parcel{Type: TypeAlert, Address: "", Payload: []byte{0}}, false, false},
-		{"message", &Parcel{Type: TypeMessage, Address: "", Payload: []byte{0}}, false, true},
-		{"messagepart", &Parcel{Type: TypeMessagePart, Address: "", Payload: []byte{0}}, false, true},
-		{"handshake", &Parcel{Type: TypeHandshake, Address: "", Payload: []byte{0}}, false, false},
-		{"reject alternative", &Parcel{Type: TypeRejectAlternative, Address: "", Payload: []byte{0}}, false, false},
-		{"out of range", &Parcel{Type: ParcelType(len(typeStrings)), Address: "", Payload: []byte{0}}, true, false},
+		{"heartbeat", &Parcel{ptype: TypeHeartbeat, Address: "", Payload: []byte{0}}, false, false},
+		{"empty payload", &Parcel{ptype: TypeHeartbeat, Address: "", Payload: []byte{}}, true, false},
+		{"ping", &Parcel{ptype: TypePing, Address: "", Payload: []byte{0}}, false, false},
+		{"pong", &Parcel{ptype: TypePong, Address: "", Payload: []byte{0}}, false, false},
+		{"p request", &Parcel{ptype: TypePeerRequest, Address: "", Payload: []byte{0}}, false, false},
+		{"p response", &Parcel{ptype: TypePeerResponse, Address: "", Payload: []byte{0}}, false, false},
+		{"alert", &Parcel{ptype: TypeAlert, Address: "", Payload: []byte{0}}, false, false},
+		{"message", &Parcel{ptype: TypeMessage, Address: "", Payload: []byte{0}}, false, true},
+		{"messagepart", &Parcel{ptype: TypeMessagePart, Address: "", Payload: []byte{0}}, false, true},
+		{"handshake", &Parcel{ptype: TypeHandshake, Address: "", Payload: []byte{0}}, false, false},
+		{"reject alternative", &Parcel{ptype: TypeRejectAlternative, Address: "", Payload: []byte{0}}, false, false},
+		{"out of range", &Parcel{ptype: ParcelType(len(typeStrings)), Address: "", Payload: []byte{0}}, true, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/peer.go
+++ b/peer.go
@@ -111,19 +111,19 @@ func (p *Peer) Send(parcel *Parcel) {
 }
 
 func (p *Peer) statLoop() {
-	ticker := time.NewTicker(time.Second * 5)
+	ticker := time.NewTicker(time.Second)
 	for {
 		select {
 		case <-ticker.C:
 			p.metricsMtx.Lock()
 			mw, mr, bw, br := p.metrics.Collect()
-			p.bpsDown = float64(br) / 5
-			p.bpsUp = float64(bw) / 5
+			p.bpsDown = float64(br)
+			p.bpsUp = float64(bw)
 			p.totalBytesReceived += br
 			p.totalBytesSent += bw
 
-			p.mpsDown = float64(mr) / 5
-			p.mpsUp = float64(mw) / 5
+			p.mpsDown = float64(mr)
+			p.mpsUp = float64(mw)
 			p.totalParcelsReceived += mr
 			p.totalParcelsSent += mw
 

--- a/prometheus.go
+++ b/prometheus.go
@@ -10,12 +10,15 @@ var once sync.Once
 
 // Prometheus holds all of the prometheus recording instruments
 type Prometheus struct {
-	Networks    prometheus.Gauge
-	Connections prometheus.Gauge // done
-	Unique      prometheus.Gauge
-	Connecting  prometheus.Gauge // done
-	Incoming    prometheus.Gauge // done
-	Outgoing    prometheus.Gauge // done
+	Connections      prometheus.Gauge
+	Connecting       prometheus.Gauge
+	Incoming         prometheus.Gauge
+	Outgoing         prometheus.Gauge
+	ToNetwork        prometheus.Gauge
+	ToNetworkRatio   prometheus.Gauge
+	FromNetwork      prometheus.Gauge
+	FromNetworkRatio prometheus.Gauge
+	CatRounds        prometheus.Counter
 
 	SendRoutines    prometheus.Gauge
 	ReceiveRoutines prometheus.Gauge
@@ -25,7 +28,10 @@ type Prometheus struct {
 	Invalid         prometheus.Counter
 	AppSent         prometheus.Counter
 	AppReceived     prometheus.Counter
-	AppDuplicate    prometheus.Counter
+	ByteRateDown    prometheus.Gauge
+	ByteRateUp      prometheus.Gauge
+	MessageRateDown prometheus.Gauge
+	MessageRateUp   prometheus.Gauge
 
 	ParcelSize prometheus.Histogram
 }
@@ -43,18 +49,28 @@ func (p *Prometheus) Setup() {
 		}
 
 		p.Connections = ng("factomd_p2p_peers_online", "Number of established connections")
-		p.Unique = ng("factomd_p2p_peers_unique", "Number of unique ip addresses connected")
 		p.Connecting = ng("factomd_p2p_peers_connecting", "Number of connections currently dialing or awaiting handshake")
 		p.Incoming = ng("factomd_p2p_peers_incoming", "Number of peers that have dialed to this node")
 		p.Outgoing = ng("factomd_p2p_peers_outgoing", "Number of peers that this node has dialed to")
+		p.ToNetwork = ng("factomd_p2p_to_network", "The number of parcels in the ToNetwork channel")
+		p.ToNetworkRatio = ng("factomd_p2p_to_network_ratio", "The fill ratio of the ToNetwork channel")
+		p.FromNetwork = ng("factomd_p2p_from_network", "The number of parcels in the FromNetwork channel")
+		p.FromNetworkRatio = ng("factomd_p2p_from_network_ratio", "The fill ratio of the FromNetwork channel")
+		p.CatRounds = ng("factomd_p2p_cat_rounds", "Number of CAT rounds")
+
 		p.SendRoutines = ng("factomd_p2p_tech_sendroutines", "Number of active send routines")
 		p.ReceiveRoutines = ng("factomd_p2p_tech_receiveroutines", "Number of active receive routines")
+
 		p.ParcelsSent = ng("factomd_p2p_parcels_sent", "Total number of parcels sent out")
 		p.ParcelsReceived = ng("factomd_p2p_parcels_received", "Total number of parcels received")
 		p.Invalid = ng("factomd_p2p_parcels_invalid", "Total number of invalid parcels received")
 		p.AppSent = ng("factomd_p2p_messages_sent", "Total number of application messages sent")
 		p.AppReceived = ng("factomd_p2p_messages_received", "Total number of application messages received")
-		p.AppDuplicate = ng("factomd_p2p_messages_duplicate", "Total number of duplicate messages filtered out")
+		p.ByteRateDown = ng("factomd_p2p_byte_rate_down", "Current rate of incoming traffic (in bytes/sec)")
+		p.ByteRateUp = ng("factomd_p2p_byte_rate_up", "Current rate of outgoing traffic (in bytes/sec)")
+		p.MessageRateDown = ng("factomd_p2p_msg_rate_down", "Current rate of incoming traffic (in messages/sec)")
+		p.MessageRateUp = ng("factomd_p2p_msg_rate_up", "Current rate of outgoing traffic (in messages/sec)")
+
 		p.ParcelSize = prometheus.NewHistogram(prometheus.HistogramOpts{
 			Name:    "factomd_p2p_parcels_size",
 			Help:    "Number of parcels encountered for specific sizes (in KiBi)",

--- a/protocolV10.go
+++ b/protocolV10.go
@@ -31,7 +31,7 @@ func (v10 *ProtocolV10) init(decoder *gob.Decoder, encoder *gob.Encoder) {
 // Send encodes a Parcel as V10Msg, calculates the crc and encodes it as gob
 func (v10 *ProtocolV10) Send(p *Parcel) error {
 	var msg V10Msg
-	msg.Type = p.Type
+	msg.Type = p.ptype
 	msg.Crc32 = crc32.Checksum(p.Payload, crcTable)
 	msg.Payload = p.Payload
 	return v10.encoder.Encode(msg)

--- a/protocolV10.go
+++ b/protocolV10.go
@@ -4,7 +4,6 @@ import (
 	"encoding/gob"
 	"encoding/json"
 	"fmt"
-	"hash/crc32"
 )
 
 var _ Protocol = (*ProtocolV10)(nil)
@@ -19,7 +18,6 @@ type ProtocolV10 struct {
 // V10Msg is the barebone message
 type V10Msg struct {
 	Type    ParcelType
-	Crc32   uint32
 	Payload []byte
 }
 
@@ -32,7 +30,6 @@ func (v10 *ProtocolV10) init(decoder *gob.Decoder, encoder *gob.Encoder) {
 func (v10 *ProtocolV10) Send(p *Parcel) error {
 	var msg V10Msg
 	msg.Type = p.ptype
-	msg.Crc32 = crc32.Checksum(p.Payload, crcTable)
 	msg.Payload = p.Payload
 	return v10.encoder.Encode(msg)
 }
@@ -52,11 +49,6 @@ func (v10 *ProtocolV10) Receive() (*Parcel, error) {
 
 	if len(msg.Payload) == 0 {
 		return nil, fmt.Errorf("null payload")
-	}
-
-	csum := crc32.Checksum(msg.Payload, crcTable)
-	if csum != msg.Crc32 {
-		return nil, fmt.Errorf("invalid checksum")
 	}
 
 	p := newParcel(msg.Type, msg.Payload)

--- a/protocolV9.go
+++ b/protocolV9.go
@@ -30,7 +30,7 @@ func (v9 *ProtocolV9) Send(p *Parcel) error {
 	var msg V9Msg
 	msg.Header.Network = v9.net.conf.Network
 	msg.Header.Version = 9 // hardcoded
-	msg.Header.Type = p.Type
+	msg.Header.Type = p.ptype
 	msg.Header.TargetPeer = p.Address
 
 	msg.Header.NodeID = uint64(v9.net.conf.NodeID)
@@ -61,7 +61,7 @@ func (v9 *ProtocolV9) Receive() (*Parcel, error) {
 	p := new(Parcel)
 	p.Address = msg.Header.TargetPeer
 	p.Payload = msg.Payload
-	p.Type = msg.Header.Type
+	p.ptype = msg.Header.Type
 	return p, nil
 }
 


### PR DESCRIPTION
Addresses some of the issues from #33

* Don't export parcel.Type to the application
* Don't export to/from network channels, instead use `Network` functions
* Fix some existing prometheus gauges and add ones for network fill ratios
* CRC32 removed for V10 (#6)

All of these are fairly straightforward except for the removal of CRC32. Detailed explanation in this post: https://github.com/WhoSoup/factom-p2p/issues/6#issuecomment-596417066