### PR TITLE
Peer resend filter

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -120,6 +120,15 @@ type Configuration struct {
 	ChannelCapacity uint
 
 	EnablePrometheus bool // Enable prometheus logging. Disable if you run multiple instances
+
+	// PeerResend turns on tracking of application parcels to preventing sending the same
+	// application parcel to peers who already sent it
+	PeerResend bool
+	// PeerResendBuckets controls the number of buckets to keep. The coverage of Resend messages
+	// equals Buckets * time.Duration
+	PeerResendBuckets int
+	// PeerResendInterval controls how wide each bucket is
+	PeerResendInterval time.Duration
 }
 
 // DefaultP2PConfiguration returns a network configuration with base values
@@ -166,6 +175,9 @@ func DefaultP2PConfiguration() (c Configuration) {
 	c.ChannelCapacity = 1000
 
 	c.EnablePrometheus = true
+	c.PeerResend = true
+	c.PeerResendBuckets = 3
+	c.PeerResendInterval = time.Second * 20
 	return
 }
 

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -59,3 +59,19 @@ func TestConfiguration_Check(t *testing.T) {
 		})
 	}
 }
+
+func TestDefaultP2PConfiguration(t *testing.T) {
+	tests := []struct {
+		name  string
+		wantC Configuration
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotC := DefaultP2PConfiguration(); !reflect.DeepEqual(gotC, tt.wantC) {
+				t.Errorf("DefaultP2PConfiguration() = %v, want %v", gotC, tt.wantC)
+			}
+		})
+	}
+}

--- a/controller_routing.go
+++ b/controller_routing.go
@@ -17,7 +17,13 @@ func (c *controller) route() {
 		case parcel := <-c.net.toNetwork:
 			switch parcel.Address {
 			case FullBroadcast:
-				for _, p := range c.peers.Slice() {
+				var selection []*Peer
+				if c.net.conf.PeerResend {
+					selection = c.selectNoResendPeers(parcel.Payload)
+				} else {
+					selection = c.peers.Slice()
+				}
+				for _, p := range selection {
 					p.Send(parcel)
 				}
 

--- a/controller_routing.go
+++ b/controller_routing.go
@@ -1,6 +1,9 @@
 package p2p
 
-import "time"
+import (
+	"crypto/sha1"
+	"time"
+)
 
 // route takes messages from ToNetwork and routes it to the appropriate peers
 func (c *controller) route() {
@@ -19,7 +22,13 @@ func (c *controller) route() {
 				}
 
 			case Broadcast:
-				selection := c.selectBroadcastPeers(c.net.conf.Fanout)
+				var selection []*Peer
+				if c.net.conf.PeerResend {
+					selection = c.selectNoResendPeers(parcel.Payload)
+				} else {
+					selection = c.peers.Slice()
+				}
+				selection = c.selectBroadcastPeers(selection, c.net.conf.Fanout)
 				for _, p := range selection {
 					p.Send(parcel)
 				}
@@ -116,9 +125,25 @@ func (c *controller) randomPeer() *Peer {
 	return nil
 }
 
-func (c *controller) selectBroadcastPeers(fanout uint) []*Peer {
-	peers := c.peers.Slice()
+func (c *controller) selectNoResendPeers(payload []byte) []*Peer {
+	all := c.peers.Slice()
 
+	if len(all) == 0 {
+		return nil
+	}
+
+	hash := sha1.Sum(payload)
+	filtered := make([]*Peer, 0, len(all))
+	for _, p := range all {
+		if !p.resend.Has(hash) {
+			filtered = append(filtered, p)
+		}
+	}
+
+	return filtered
+}
+
+func (c *controller) selectBroadcastPeers(peers []*Peer, fanout uint) []*Peer {
 	// not enough to randomize
 	if uint(len(peers)) <= fanout {
 		return peers

--- a/controller_routing_test.go
+++ b/controller_routing_test.go
@@ -1,6 +1,9 @@
 package p2p
 
 import (
+	"crypto/sha1"
+	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 )
@@ -175,5 +178,36 @@ func Test_controller_manageData(t *testing.T) {
 		t.Errorf("async response did not deliver")
 	} else if p := <-async; p.ptype != TypePeerResponse {
 		t.Errorf("peer response did not send right response. got = %s, want = %s", p.ptype, TypePeerResponse)
+	}
+}
+
+func Test_controller_selectNoReplayPeers(t *testing.T) {
+	payload := make([]byte, 1024)
+	rand.Read(payload)
+	hash := sha1.Sum(payload)
+
+	net := testNetworkHarness(t)
+	net.conf.MaxPeers = 8
+	for i := 0; i < int(net.conf.MaxPeers); i++ {
+		net.controller.peers.Add(testRandomPeer(net))
+	}
+
+	peers := net.controller.peers.Slice()
+
+	for i := 0; i < 4; i++ {
+		peers[i].resend.Add(hash)
+		fmt.Printf("registered hash with peer %s\n", peers[i].Hash)
+	}
+
+	filtered := net.controller.selectNoResendPeers(payload)
+	if len(filtered) != 4 {
+		t.Errorf("invalid number of peers selected. got = %d, want = 4", len(filtered))
+	}
+	for _, f := range filtered {
+		for i := 0; i < 4; i++ {
+			if f.Hash == peers[i].Hash {
+				t.Errorf("peer %s was mistakenly included", f.Hash)
+			}
+		}
 	}
 }

--- a/peerResend.go
+++ b/peerResend.go
@@ -1,0 +1,99 @@
+package p2p
+
+import (
+	"crypto/sha1"
+	"sync"
+	"time"
+)
+
+type PeerResend struct {
+	mtx      sync.RWMutex
+	buckets  []*PRBucket
+	pc       int
+	interval time.Duration
+	stopper  chan interface{}
+}
+
+type PRBucket struct {
+	mtx  sync.RWMutex
+	data map[[sha1.Size]byte]bool
+}
+
+func (b *PRBucket) Has(hash [sha1.Size]byte) bool {
+	b.mtx.RLock()
+	defer b.mtx.RUnlock()
+	return b.data[hash]
+}
+
+func (b *PRBucket) Add(hash [sha1.Size]byte) {
+	b.mtx.Lock()
+	defer b.mtx.Unlock()
+	b.data[hash] = true
+}
+
+func NewPeerResend(buckets int, interval time.Duration) *PeerResend {
+	pr := new(PeerResend)
+	pr.interval = interval
+	pr.buckets = make([]*PRBucket, buckets)
+	for i := 0; i < buckets; i++ {
+		pr.buckets[i] = newPRBucket()
+	}
+	pr.stopper = make(chan interface{}, 1)
+	go pr.Cleanup()
+	return pr
+}
+
+func newPRBucket() *PRBucket {
+	b := new(PRBucket)
+	b.data = make(map[[sha1.Size]byte]bool)
+	return b
+}
+
+func (pr *PeerResend) Has(hash [sha1.Size]byte) bool {
+	pr.mtx.RLock()
+	defer pr.mtx.RUnlock()
+
+	for i := 0; i < len(pr.buckets); i++ {
+		if pr.buckets[pr.ptr(i)].Has(hash) {
+			return true
+		}
+	}
+	return false
+}
+
+func (pr *PeerResend) Add(hash [sha1.Size]byte) {
+	pr.mtx.RLock()
+	defer pr.mtx.RUnlock()
+	pr.buckets[pr.pc].Add(hash)
+}
+
+func (pr *PeerResend) Stop() {
+	close(pr.stopper)
+}
+
+func (pr *PeerResend) Cleanup() {
+	ticker := time.NewTicker(pr.interval)
+	for {
+		select {
+		case <-pr.stopper:
+			return
+		case <-ticker.C:
+			pr.dropOldestBucket()
+		}
+	}
+}
+
+func (pr *PeerResend) dropOldestBucket() {
+	pr.mtx.Lock()
+	pr.pc--
+	if pr.pc < 0 {
+		pr.pc += len(pr.buckets)
+	}
+	pr.buckets[pr.pc] = newPRBucket()
+	pr.mtx.Unlock()
+}
+
+// not thread safe
+func (pr *PeerResend) ptr(i int) int {
+	return (pr.pc + i) % len(pr.buckets)
+}

--- a/peerResend_test.go
+++ b/peerResend_test.go
@@ -1,0 +1,135 @@
+package p2p
+
+import (
+	"crypto/sha1"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func _newTestPeerResend(buckets int, interval time.Duration) *PeerResend {
+	pr := new(PeerResend)
+	pr.interval = interval
+	pr.buckets = make([]*PRBucket, buckets)
+	for i := 0; i < buckets; i++ {
+		pr.buckets[i] = newPRBucket()
+	}
+	pr.stopper = make(chan interface{}, 1)
+	return pr
+}
+
+func rhash(l int) [sha1.Size]byte {
+	r := make([]byte, l)
+	rand.Read(r)
+	return sha1.Sum(r)
+}
+
+func TestPRBucket(t *testing.T) {
+	bucket := newPRBucket()
+
+	testset := make([][sha1.Size]byte, 128)
+	for i := range testset {
+		testset[i] = rhash(rand.Intn(512) + 64)
+	}
+
+	for _, h := range testset {
+		if bucket.Has(h) {
+			t.Error("empty bucket reports it has %h", h)
+		}
+	}
+
+	for i := 0; i < 64; i++ {
+		bucket.Add(testset[i])
+	}
+
+	for i, h := range testset {
+		has := bucket.Has(h)
+		if i >= 64 {
+			if has {
+				t.Error("full bucket reports it has %h when it shouldn't", h)
+			}
+		} else {
+			if !has {
+				t.Error("bucket should have %h but doesn't", h)
+			}
+		}
+	}
+}
+
+func TestPRBucket_MultiThreaded_Try(t *testing.T) {
+
+	pr := _newTestPeerResend(16, time.Hour)
+
+	done := make(chan bool, 8)
+	testroutine := func() {
+		testset := make([][sha1.Size]byte, 1024)
+		for i := range testset {
+			testset[i] = rhash(rand.Intn(512) + 64)
+			pr.Add(testset[i])
+		}
+
+		for _, p := range testset {
+			if !pr.Has(p) {
+				t.Errorf("data missing")
+			}
+		}
+
+		done <- true
+	}
+
+	for i := 0; i < 8; i++ {
+		go testroutine()
+	}
+
+	for i := 0; i < 8; i++ {
+		<-done
+	}
+}
+
+func TestPRBucket_MultiThreaded_Cleanup(t *testing.T) {
+	testpl := sha1.Sum([]byte{0xff, 0x00, 0x00})
+
+	pr := _newTestPeerResend(1, time.Hour)
+
+	pr.Add(testpl)
+	pr.dropOldestBucket()
+
+	if pr.Has(testpl) {
+		t.Errorf("single bucket didn't get cleaned properly")
+	}
+
+	pr = _newTestPeerResend(2, time.Hour)
+
+	pr.Add(testpl)
+	pr.dropOldestBucket()
+
+	if !pr.Has(testpl) {
+		t.Errorf("item not found but should still be in bucket #2")
+	}
+
+	pr.dropOldestBucket()
+	if pr.Has(testpl) {
+		t.Errorf("double bucket didn't get cleaned properly")
+	}
+
+	pr = NewPeerResend(3, time.Millisecond*50)
+
+	pr.Add(testpl)
+
+	time.Sleep(time.Millisecond * 75)
+	if !pr.Has(testpl) {
+		t.Errorf("timed item not found")
+	}
+
+	time.Sleep(time.Millisecond * 100) // 175 ms > 150 ms
+	if pr.Has(testpl) {
+		t.Errorf("timed bucket didn't get cleaned properly")
+	}
+	pr.Stop()
+	pr.Add(testpl)
+
+	time.Sleep(time.Millisecond * 200)
+	if !pr.Has(testpl) {
+		t.Errorf("timed bucket didn't get stopped properly")
+	}
+}

--- a/peer_test.go
+++ b/peer_test.go
@@ -29,6 +29,9 @@ func testRandomPeer(net *Network) *Peer {
 	p.send = newParcelChannel(p.net.conf.ChannelCapacity)
 	p.IsIncoming = net.rng.Intn(1) == 0
 	p.connected = time.Now()
+	if net.conf.PeerResend {
+		p.resend = NewPeerResend(net.conf.PeerResendBuckets, net.conf.PeerResendInterval)
+	}
 	return p
 }
 


### PR DESCRIPTION
Re-implementation of Clay's p2p filter, where the goal is to stop broadcast messages from being delivered to peers who sent us that message originally. This is accomplished by a bucket-based filter, which stores SHA1 hashes of message payloads. 

When a peer received an application message, it registers the payload hash in the resend filter. When peers are selected for broadcast, peers containing that message's payload hash are not selected.

Overall, this will increase message propagation to prefer sending messages to new peers. If more than `Fanout` peers send us the message before the application rebroadcasts it, it will also save bandwidth.