### PR TITLE
Fix flaky unit test

### DIFF
--- a/controller_routing_test.go
+++ b/controller_routing_test.go
@@ -161,6 +161,8 @@ func Test_controller_manageData(t *testing.T) {
 	}()
 
 	net.controller.manageData()
+	// give asynchronous requests some time to finish before checking
+	time.Sleep(time.Millisecond * 500)
 
 	if len(ping.send) != 1 {
 		t.Errorf("ping peer did not receive pong")


### PR DESCRIPTION
In the Test_controller_manageData, one of the tests was routing a peer share, which happens inside a goroutine. A race condition sometimes occurred where the controller was stopped and the unit test checked before the goroutine finished.